### PR TITLE
Ballistics - Add Overwrite function for unsafe ammo

### DIFF
--- a/addons/ballistics/XEH_PREP.hpp
+++ b/addons/ballistics/XEH_PREP.hpp
@@ -1,4 +1,5 @@
 PREP(destroy);
 PREP(expandUnsafeAmmo);
+PREP(isKeyDefault);
 PREP(registerEventHandlers);
 PREP(registerUnsafeAmmo);

--- a/addons/ballistics/XEH_PREP.hpp
+++ b/addons/ballistics/XEH_PREP.hpp
@@ -1,5 +1,6 @@
 PREP(destroy);
 PREP(expandUnsafeAmmo);
 PREP(isKeyDefault);
+PREP(overwriteUnsafeAmmo);
 PREP(registerEventHandlers);
 PREP(registerUnsafeAmmo);

--- a/addons/ballistics/functions/fnc_destroy.sqf
+++ b/addons/ballistics/functions/fnc_destroy.sqf
@@ -7,7 +7,7 @@
  * 0: Entity <OBJECT>
  *
  * Return Value:
- * 0: NONE
+ * None
  *
  * Example:
  * [] call misery_ballistics_fnc_destroy;

--- a/addons/ballistics/functions/fnc_expandUnsafeAmmo.sqf
+++ b/addons/ballistics/functions/fnc_expandUnsafeAmmo.sqf
@@ -8,7 +8,7 @@
  * 1: Safe Ammunitions <ARRAY>
  *
  * Return Value:
- * 0: NONE
+ * None
  *
  * Example:
  * ["Rabbit_F", ["B_9x21_Ball", "B_12Gauge_Pellets"]] call misery_ballistics_fnc_expandUnsafeAmmo;

--- a/addons/ballistics/functions/fnc_isKeyDefault.sqf
+++ b/addons/ballistics/functions/fnc_isKeyDefault.sqf
@@ -1,0 +1,18 @@
+#include "..\script_component.hpp"
+/*
+ * Author: MikeMF
+ * Checks if hashmap key is new
+ *
+ * Arguments:
+ * 0: Key Classname <CLASSNAME>
+ *
+ * Return Value:
+ * 0: Key Exists <BOOL>
+ *
+ * Example:
+ * ["Rabbit_F"] call misery_ballistics_fnc_isKeyDefault
+*/
+
+params ["_classname"];
+
+(GVAR(ballisticsMap) getOrDefault [_classname, []]) isEqualTo []

--- a/addons/ballistics/functions/fnc_overwriteUnsafeAmmo.sqf
+++ b/addons/ballistics/functions/fnc_overwriteUnsafeAmmo.sqf
@@ -1,0 +1,25 @@
+#include "..\script_component.hpp"
+/*
+ * Author: MikeMF
+ * Public method to overwrite previously set definitions completely.
+ *
+ * Arguments:
+ * 0: Animal / Unit Classname <CLASSNAME>
+ * 1: New ammunition <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["Rabbit_F", ["B_9x21_Ball", "B_12Gauge_Pellets"]] call misery_ballistics_fnc_overwriteUnsafeAmmo
+*/
+
+params ["_classname", "_unsafeAmmo"];
+
+// Exit if classname isn't registered
+if (_classname call FUNC(isKeyDefault)) exitWith {
+    diag_log format ["[MISERY] - Unsafe ammo class cannot be overwritten because it does not exist for (%1)", _classname];
+};
+
+// Overwrite
+GVAR(ballisticsMap) set [_classname, _unsafeAmmo];

--- a/addons/ballistics/functions/fnc_registerEventHandlers.sqf
+++ b/addons/ballistics/functions/fnc_registerEventHandlers.sqf
@@ -7,7 +7,7 @@
  * 0: Animal / Unit Classname <CLASSNAME>
  *
  * Return Value:
- * 0: NONE
+ * None
  *
  * Example:
  * ["Rabbit_F"] call misery_ballistics_fnc_registerEventHandlers;

--- a/addons/ballistics/functions/fnc_registerUnsafeAmmo.sqf
+++ b/addons/ballistics/functions/fnc_registerUnsafeAmmo.sqf
@@ -9,7 +9,7 @@
  * 1: Safe Ammunitions <ARRAY>
  *
  * Return Value:
- * 0: NONE
+ * None
  *
  * Example:
  * ["Rabbit_F", ["B_9x21_Ball", "B_12Gauge_Pellets"]] call misery_ballistics_fnc_registerUnsafeAmmo;
@@ -19,10 +19,8 @@ if (!isServer) exitWith {};
 
 params ["_classname", "_unsafeAmmo"];
 
-private _isKeyDefault = (GVAR(ballisticsMap) getOrDefault [_classname, []]) isEqualTo [];
-
 // Add if key returns default value.
-if (_isKeyDefault) exitWith {
+if (_classname call FUNC(isKeyDefault)) exitWith {
     GVAR(ballisticsMap) set [_classname, _unsafeAmmo];
     _classname call FUNC(registerEventHandlers);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a hard overwrite function to replace the current one for the classname.
- Adds `isKeyDefault` function to check if the key is new or not.

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
