### PR TITLE
Fix - Loot, setting category name

### DIFF
--- a/addons/loot/initSettings.inc.sqf
+++ b/addons/loot/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = format ["Misery %1", QUOTE(COMPONENT_BEAUTIFIED)];
+private _category = format ["Misery - %1", QUOTE(COMPONENT_BEAUTIFIED)];
 
 [QGVAR(enabled),
     "CHECKBOX",


### PR DESCRIPTION
**When merged this pull request will:**
- Add a hyphen to Loot settings (as it is the only component missing one)

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
