### PR TITLE
Rework gasmask decrementing

### DIFF
--- a/addons/gasmask/initSettings.inc.sqf
+++ b/addons/gasmask/initSettings.inc.sqf
@@ -1,15 +1,6 @@
 private _category = format ["Misery - %1", QUOTE(COMPONENT_BEAUTIFIED)];
 
 [
-    QGVAR(deficiencyCycle),
-    "SLIDER",
-    ["Gasmask deficiency cycle", "Defines when Cartridge capacity decreases (Requires Enhanced gasmasks)"],
-    _category,
-    [1, 300, 15, 0],
-    1
-] call CBA_fnc_addSetting;
-
-[
     QGVAR(enhanced),
     "CHECKBOX",
     ["Enhanced gasmasks", "Enable enhanced gasmasks? (Makes all gasmasks vulnerable to cartridge failure, while gasmasks are worn cartridges deplete. If a rebreather is equipped, this isn't active due to using a rebreather for supplied air)"],


### PR DESCRIPTION
**When merged this pull request will:**
- worked in hazardous zones for decrementing cartridge efficiency

- removed timer for cartridge depletion, now hard-coded to every 10 seconds

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
