### PR TITLE
Assets - Fix all items being mine detectors

### DIFF
--- a/addons/assets/CfgWeapons.hpp
+++ b/addons/assets/CfgWeapons.hpp
@@ -9,7 +9,6 @@ class CfgWeapons {
         type = 4096;
         detectRange = -1;
         scopeCurator = 2;
-        simulation = "ItemMineDetector";
     };
 
     class CLASS(pickaxe): CLASS(ItemCore) {


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Inherits from itemCore, simulation is default.

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
