### PR TITLE
Fire - Remove auto craft action

### DIFF
--- a/addons/fire/XEH_postInit.sqf
+++ b/addons/fire/XEH_postInit.sqf
@@ -1,19 +1,6 @@
 #include "script_component.hpp"
 
 [
-    "fireCrafting_menu",
-    "Craft fire",
-    {call FUNC(condition)},
-    {
-        [QEGVAR(common,exitGui)] call CBA_fnc_localEvent;
-        createDialog QCLASS(fireCrafting_ui);
-    },
-    "",
-    QPATHTOEF(icons,data\nearfire_ca.paa),
-    ""
-] call EFUNC(actions,addAction);
-
-[
     "fire_menu",
     localize "STR_MISERY_USEFIRE",
     {call EFUNC(common,nearFire) params ["_nearestFire"]; _nearestFire isNotEqualTo []},


### PR DESCRIPTION
**When merged this pull request will:**
- removed automated craft fire action (action now added scenario side to items)

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
