### PR TITLE
DoorLocks - Add

### DIFF
--- a/addons/assets/CfgWeapons.hpp
+++ b/addons/assets/CfgWeapons.hpp
@@ -1293,6 +1293,19 @@ class CfgWeapons {
         };
     };
 
+    class CLASS(lockKit): CLASS(ItemCore) {
+        displayName = "Door lock kit";
+        descriptionShort = "electronic door locking kit, prevents unauthorized entry once installed";
+        model = "a3\weapons_f\items\toolkit.p3d";
+        picture = QPATHTOF(data\icons\toolkit.paa);
+        scope = 2;
+        scopeCurator = 2;
+
+        class ItemInfo: CBA_MiscItem_ItemInfo {
+            mass = 25;
+        };
+    };
+
     class CLASS(stoneChunk): CLASS(ItemCore) {
         displayName = "$STR_MISERY_STONECHUNK_DISPLAYNAME";
         descriptionShort = "$STR_MISERY_STONECHUNK_DESCRIPTION";

--- a/addons/doorlocks/$PBOPREFIX$
+++ b/addons/doorlocks/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\misery\addons\doorlocks

--- a/addons/doorlocks/CfgEventHandlers.hpp
+++ b/addons/doorlocks/CfgEventHandlers.hpp
@@ -1,0 +1,11 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+    };
+};

--- a/addons/doorlocks/XEH_PREP.hpp
+++ b/addons/doorlocks/XEH_PREP.hpp
@@ -1,0 +1,8 @@
+PREP(applyBuildingStates);
+PREP(countDoors);
+PREP(disableLocks);
+PREP(enableLocks);
+PREP(installLocks);
+PREP(ProcessPin);
+PREP(promptPin);
+PREP(updateBuildingState);

--- a/addons/doorlocks/XEH_postInit.sqf
+++ b/addons/doorlocks/XEH_postInit.sqf
@@ -1,0 +1,51 @@
+#include "script_component.hpp"
+
+if (hasInterface) then {
+    [
+        "installLock_menu",
+        "Install Door Locks",
+        {[[QCLASS(lockKit)]] call EFUNC(common,hasItem) && {call FUNC(countDoors) params ["_doorCount", "_building", "_noLock"]; !_noLock && _doorCount > 0 && !isNull _building && isNil {_building getVariable QGVAR(doorPin)}}},
+        {
+            [QEGVAR(common,exitGui)] call CBA_fnc_localEvent;
+            GVAR(pinMode) = 0;
+            [] call FUNC(installLocks);
+        },
+        "",
+        QUOTE(a3\modules_f\data\editterrainobject\texturechecked_door_ca.paa),
+        ""
+    ] call EFUNC(actions,addAction);
+
+    [
+        "unlockDoors_menu",
+        "Unlock Doors",
+        {call FUNC(countDoors) params ["_doorCount", "_building"]; _doorCount > 0 && !isNull _building && (_building getVariable [QGVAR(doorsLocked), false])},
+        {
+            [QEGVAR(common,exitGui)] call CBA_fnc_localEvent;
+            GVAR(pinMode) = 1;
+            [] call FUNC(promptPin);
+        },
+        "",
+        QUOTE(a3\modules_f\data\editterrainobject\textureunchecked_door_ca.paa),
+        ""
+    ] call EFUNC(actions,addAction);
+
+    [
+        "lockDoors_menu",
+        "Lock Doors",
+        {call FUNC(countDoors) params ["_doorCount", "_building"]; _doorCount > 0 && !isNull _building && !(_building getVariable [QGVAR(doorsLocked), false]) && {!isNil {_building getVariable QGVAR(doorPin)}}},
+        {
+            [QEGVAR(common,exitGui)] call CBA_fnc_localEvent;
+            GVAR(pinMode) = 1;
+            [] call FUNC(promptPin);
+        },
+        "",
+        QUOTE(a3\modules_f\data\editterrainobject\texturedoor_locked_ca.paa),
+        ""
+    ] call EFUNC(actions,addAction);
+};
+
+if (isServer) then {
+    [{
+        call FUNC(applyBuildingStates);
+    }, [], 1] call CBA_fnc_waitAndExecute;
+};

--- a/addons/doorlocks/XEH_preInit.sqf
+++ b/addons/doorlocks/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "XEH_PREP.hpp"
+
+ADDON = true;

--- a/addons/doorlocks/config.cpp
+++ b/addons/doorlocks/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {QCLASS(common)};
+        authors[] = {"TenuredCLOUD"};
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+
+

--- a/addons/doorlocks/functions/fnc_applyBuildingStates.sqf
+++ b/addons/doorlocks/functions/fnc_applyBuildingStates.sqf
@@ -1,0 +1,37 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Applies lock states to buildings
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_doorlocks_fnc_applyBuildingStates
+ *
+ */
+
+if (!isServer) exitWith {};
+
+private _states = missionNamespace getVariable [QGVAR(buildingStates), []];
+{
+    _x params ["_posStr", "_doorsLocked", "_pin"];
+    private _pos = call compile _posStr;
+    private _building = nearestBuilding _pos;
+    if (!isNull _building) then {
+        if (_doorsLocked) then {
+            _building setVariable [QGVAR(doorsLocked), true, true];
+            private _config = [_building] call CBA_fnc_getObjectConfig;
+            private _doorCount = getNumber (_config >> "numberOfDoors");
+            for "_i" from 1 to _doorCount do {
+                _building setVariable [format ["bis_disabled_Door_%1", _i], 1, true];
+            };
+        };
+        if (_pin isNotEqualTo 0) then {
+            _building setVariable [QGVAR(doorPin), _pin, true];
+        };
+    };
+} forEach _states;

--- a/addons/doorlocks/functions/fnc_countDoors.sqf
+++ b/addons/doorlocks/functions/fnc_countDoors.sqf
@@ -1,0 +1,38 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Grabs number of doors from object config
+ * Also runs model check and ignores models known to not lock
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * 0: Doors <NUMBER>
+ * 1: Nearest Building <OBJECT>
+ * 2: No lock <BOOL>
+ *
+ * Example:
+ * [] call misery_doorlocks_fnc_countDoors
+ *
+*/
+
+private _building = cursorObject;
+
+if !(_building isKindOf "House") exitWith {
+    [0, objNull, true];
+};
+
+if (player distance _building > 25) exitWith {
+    [0, objNull, true];
+};
+
+private _config = [_building] call CBA_fnc_getObjectConfig;
+
+private _doorCount = getNumber (_config >> "numberOfDoors");
+
+private _model = toLower ((getModelInfo _building) select 0);
+
+private _hasNoLock = _model in [MACRO_NODOORLOCK_MODELS];
+
+[_doorCount, _building, _hasNoLock]

--- a/addons/doorlocks/functions/fnc_disableLocks.sqf
+++ b/addons/doorlocks/functions/fnc_disableLocks.sqf
@@ -1,0 +1,25 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Disables door locking logic
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_doorlocks_fnc_disableLocks
+ *
+*/
+
+call FUNC(countDoors) params ["_doorCount", "_building"];
+
+for "_i" from 1 to _doorCount do {
+    _building setVariable [format ["bis_disabled_Door_%1", _i], 0, true];
+};
+
+_building setVariable [QGVAR(doorsLocked), false, true];
+
+["Doors unlocked", 1, [1, 1, 1, 1]] call CBA_fnc_notify;

--- a/addons/doorlocks/functions/fnc_enableLocks.sqf
+++ b/addons/doorlocks/functions/fnc_enableLocks.sqf
@@ -1,0 +1,29 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Enables door locking logic
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_doorlocks_fnc_enableLocks
+ *
+*/
+
+call FUNC(countDoors) params ["_doorCount", "_building"];
+
+if (_building getVariable [QGVAR(doorsLocked), false]) exitWith {
+    ["Doors are already locked...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+};
+
+for "_i" from 1 to _doorCount do {
+    _building setVariable [format ["bis_disabled_Door_%1", _i], 1, true];
+};
+
+_building setVariable [QGVAR(doorsLocked), true, true];
+
+["Doors locked", 1, [1, 1, 1, 1]] call CBA_fnc_notify;

--- a/addons/doorlocks/functions/fnc_installLocks.sqf
+++ b/addons/doorlocks/functions/fnc_installLocks.sqf
@@ -1,0 +1,23 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Simulates lock Install to building
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_doorlocks_fnc_installLocks
+ *
+*/
+
+if !([[QCLASS(lockKit)]] call EFUNC(common,hasItem)) exitWith {
+    ["No door lock kit in inventory...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+};
+
+[player, QCLASS(lockKit)] call CBA_fnc_removeItem;
+
+[] call FUNC(promptPin);

--- a/addons/doorlocks/functions/fnc_processPin.sqf
+++ b/addons/doorlocks/functions/fnc_processPin.sqf
@@ -1,0 +1,45 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Processes entered PIN
+ *
+ * Arguments:
+ * 0: PIN <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_doorlocks_fnc_processPin
+ *
+*/
+
+params ["_pin"];
+
+call FUNC(countDoors) params ["", "_building"];
+
+if (_building isEqualTo objNull) exitWith {};
+
+if (GVAR(pinMode) isEqualTo 0) then {
+    _building setVariable [QGVAR(doorPin), _pin, true];
+    private _pinSetTip = format ["Locking PIN has been set: %1", [_pin, 1, 0, false]call CBA_fnc_formatNumber];
+    [_pinSetTip, 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+    [] call FUNC(enableLocks);
+    [_building, true, _pin] call FUNC(updateBuildingState);
+} else {
+    private _saved = _building getVariable [QGVAR(doorPin), 0];
+    if (_pin isEqualTo _saved) then {
+        if (_building getVariable [QGVAR(doorsLocked), false]) then {
+            [] call FUNC(disableLocks);
+            [_building, false, _saved] call FUNC(updateBuildingState);
+        } else {
+            [] call FUNC(enableLocks);
+            [_building, true, _saved] call FUNC(updateBuildingState);
+        };
+    } else {
+        ["Wrong PIN...", 1, [1, 0, 0, 1]] call CBA_fnc_notify;
+    };
+};
+
+GVAR(pinMode) = nil;
+

--- a/addons/doorlocks/functions/fnc_promptPin.sqf
+++ b/addons/doorlocks/functions/fnc_promptPin.sqf
@@ -1,0 +1,34 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Prompts player with pin pad entry
+ *
+ * Arguments:
+ * 0: Mode <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_doorlocks_fnc_promptPin
+ *
+*/
+
+createDialog QCLASS(doorLock_ui);
+
+private _display = findDisplay 696677;
+
+private _enter = _display displayCtrl 1600;
+_enter ctrlAddEventHandler ["ButtonClick", {
+
+    private _pin = ((ctrlText ((findDisplay 696677) displayCtrl 1400))) call BIS_fnc_parseNumber;
+
+    if !(_pin isEqualType 0) exitWith {
+        ["PIN must be a number...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+    };
+
+    [_pin] call FUNC(processPin);
+    closeDialog 2;
+}];
+
+

--- a/addons/doorlocks/functions/fnc_updateBuildingState.sqf
+++ b/addons/doorlocks/functions/fnc_updateBuildingState.sqf
@@ -1,0 +1,33 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Updates global building states
+ *
+ * Arguments:
+ * 0: Building <OBJECT>
+ * 1: Doors Locked <BOOL>
+ * 2: PIN <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_doorlocks_fnc_updateBuildingState
+ *
+ */
+
+params ["_building", "_doorsLocked", ["_pin", 0]];
+
+if (isNull _building) exitWith {};
+
+private _posStr = str (getPosATL _building);  // Key buildings by pos
+private _states = missionNamespace getVariable [QGVAR(buildingStates), []];
+
+private _index = _states findIf {(_x select 0) isEqualTo _posStr};
+if (_index isNotEqualTo -1) then {
+    _states set [_index, [_posStr, _doorsLocked, _pin]];
+} else {
+    _states pushBack [_posStr, _doorsLocked, _pin];
+};
+
+missionNamespace setVariable [QGVAR(buildingStates), _states, true];

--- a/addons/doorlocks/script_component.hpp
+++ b/addons/doorlocks/script_component.hpp
@@ -1,0 +1,16 @@
+#define COMPONENT doorlocks
+#define COMPONENT_BEAUTIFIED DoorLocks
+#include "\z\misery\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+
+#ifdef DEBUG_ENABLED_DOORLOCKS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_DOORLOCKS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_DOORLOCKS
+#endif
+
+#include "\z\misery\addons\main\script_macros.hpp"

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -162,6 +162,42 @@
 "ground_sheet_opfor_f.p3d", \
 "ground_sheet_yellow_f.p3d"
 
+// Door locks - building models that don't lock
+#define MACRO_NODOORLOCK_MODELS \
+"ds_housev_1t.p3d", \
+"shed_w03.p3d", \
+"ind_garage01.p3d", \
+"a_office02.p3d", \
+"strazni_vez.p3d", \
+"ds_housev_2t1.p3d", \
+"shed_m03.p3d", \
+"shed_w02.p3d", \
+"misc_waterstation.p3d", \
+"ds_housev_2i.p3d", \
+"ds_housev_2l.p3d", \
+"shed_01_f.p3d", \
+"ds_housev_3i1.p3d", \
+"sara_zluty_statek_in.p3d", \
+"ds_housev_3i4.p3d", \
+"ds_housev_3i2.p3d", \
+"ds_housev_1l2.p3d", \
+"sara_domek_zluty.p3d", \
+"church_03.p3d", \
+"shed_w01.p3d", \
+"shed_m01.p3d", \
+"barn_metal.p3d", \
+"nav_boathouse.p3d", \
+"ds_housev_2t2.p3d", \
+"ds_housev_3i3.p3d", \
+"shed_wooden.p3d", \
+"a_tvtower_base.p3d", \
+"garaz_long_open.p3d", \
+"budova4_in.p3d", \
+"ind_pec_02.p3d", \
+"rail_station_big_f.p3d", \
+"a_hospital.p3d", \
+"a_office02.p3d"
+
 // Artifacts
 #define MACRO_ARTIFACTS QCLASS(artifact_01), QCLASS(artifact_02), QCLASS(artifact_03), QCLASS(artifact_04), QCLASS(artifact_05), QCLASS(artifact_06), QCLASS(artifact_07), QCLASS(artifact_08), QCLASS(artifact_09), QCLASS(artifact_10)
 

--- a/addons/ui/config.cpp
+++ b/addons/ui/config.cpp
@@ -41,6 +41,7 @@ class CfgPatches {
 #include "menus\refuelVehicle.hpp"
 #include "menus\refill_fuelCan.hpp"
 #include "menus\grad_persistence.hpp"
+#include "menus\doorLock.hpp"
 
 class RscTitles {
     #include "menus\geiger.hpp"

--- a/addons/ui/menus/doorLock.hpp
+++ b/addons/ui/menus/doorLock.hpp
@@ -1,0 +1,54 @@
+class CLASS(doorLock_ui) {
+    idd = 696677;
+    onLoad = QUOTE([696677] call EFUNC(common,menuBlurEffect));
+
+    class ControlsBackground {
+        class misery_doorLock_background: misery_RscText
+        {
+            idc = -1;
+            x = 12 * GUI_GRID_W + GUI_GRID_X;
+            y = 8.5 * GUI_GRID_H + GUI_GRID_Y;
+            w = 16 * GUI_GRID_W;
+            h = 8 * GUI_GRID_H;
+            colorBackground[] = {0,0,0,0.7};
+        };
+        class misery_doorLock_prompt: RscText
+        {
+            idc = 1000;
+            text = "PIN Entry:"; //--- ToDo: Localize;
+            x = 12.5 * GUI_GRID_W + GUI_GRID_X;
+            y = 8.5 * GUI_GRID_H + GUI_GRID_Y;
+            w = 11 * GUI_GRID_W;
+            h = 2 * GUI_GRID_H;
+            font = UI_MACRO_FONT;
+            sizeEx = UI_MACRO_TEXTSIZE;
+        };
+    };
+    class Controls {
+        class misery_doorLock_inputBox: RscEdit
+        {
+            idc = 1400;
+            x = 16 * GUI_GRID_W + GUI_GRID_X;
+            y = 11.5 * GUI_GRID_H + GUI_GRID_Y;
+            w = 8 * GUI_GRID_W;
+            h = 1.5 * GUI_GRID_H;
+            font = UI_MACRO_FONT;
+            sizeEx = UI_MACRO_TEXTSIZE;
+        };
+        class misery_doorLock_enter: RscButton
+        {
+            idc = 1600;
+            text = "Enter"; //--- ToDo: Localize;
+            x = 16 * GUI_GRID_W + GUI_GRID_X;
+            y = 13.5 * GUI_GRID_H + GUI_GRID_Y;
+            w = 8 * GUI_GRID_W;
+            h = 2 * GUI_GRID_H;
+            font = UI_MACRO_FONT;
+            sizeEx = UI_MACRO_TEXTSIZE;
+            colorBackground[] = {0.2, 0.2, 0.2, 0.7};
+            colorFocused[] = {0.5, 0.5, 0.5, 0.7};
+            colorActive[] = {0.5, 0.5, 0.5, 0.7};
+        };
+    };
+};
+


### PR DESCRIPTION
**When merged this pull request will:**

- added new component "doorlocks"

- added new asset "Door lock kit", allows players to set a pin lock on terrain buildings

- added logic for building door mapping, with available config data

- added new actions for installment of door locks, unlocking doors and locking doors

- added macro that lists models known to not lock even when set to

- added new pin entry menu ui

- added GRAD persistence compatibility for door lock states and pins

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
