### PR TITLE
Sleep - Improve sleeping positions

### DIFF
--- a/addons/sleep/functions/fnc_condition.sqf
+++ b/addons/sleep/functions/fnc_condition.sqf
@@ -22,4 +22,15 @@ private _object = cursorObject;
 
 private _model = getModelInfo _object select 0;
 
-_nearObjects isNotEqualTo [] || _nearTerrainObjects isNotEqualTo [] || vehicle player isKindOf "Car" || _model in [MACRO_BED_MODELS]
+private _vehicleConfig = "";
+
+private _canSleepInVehicle = false;
+
+if !(isNull objectParent player) then {
+    _vehicleConfig = configOf (vehicle player);
+    if (getNumber (_vehicleConfig >> "transportSoldier") > 1) then {
+        _canSleepInVehicle = true;
+    };
+};
+
+_nearObjects isNotEqualTo [] || _nearTerrainObjects isNotEqualTo [] || (vehicle player isKindOf "Car" && _canSleepInVehicle) || _model in [MACRO_BED_MODELS]


### PR DESCRIPTION
**When merged this pull request will:**
- added `transportSoldier` config values to sleep condition, low transport vehicles (ATV's, etc...) should no longer allow sleeping

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
