### PR TITLE
Block Bag Access - Add 

### DIFF
--- a/addons/block_bag_access/$PBOPREFIX$
+++ b/addons/block_bag_access/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\misery\addons\block_bag_access

--- a/addons/block_bag_access/CfgActions.hpp
+++ b/addons/block_bag_access/CfgActions.hpp
@@ -1,0 +1,7 @@
+class CfgActions {
+    class None;
+    // Open bag removal from unit actions
+    class OpenBag: None {
+        show = 0;
+    };
+};

--- a/addons/block_bag_access/config.cpp
+++ b/addons/block_bag_access/config.cpp
@@ -1,0 +1,15 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {QCLASS(common)};
+        authors[] = {"TenuredCLOUD"};
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgActions.hpp"

--- a/addons/block_bag_access/script_component.hpp
+++ b/addons/block_bag_access/script_component.hpp
@@ -1,0 +1,16 @@
+#define COMPONENT block_bag_access
+#define COMPONENT_BEAUTIFIED Block Bag Access
+#include "\z\misery\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+
+#ifdef DEBUG_ENABLED_BLOCK_BAG_ACCESS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_BLOCK_BAG_ACCESS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_BLOCK_BAG_ACCESS
+#endif
+
+#include "\z\misery\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- added new component, block_bag_access

- removes action to open bags from NPC's & players, prevents pick-pocketing and rating decrement on taking items from others inventories

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
