### PR TITLE
Supply drop - Fix Crate damage

### DIFF
--- a/addons/supply_drop/functions/fnc_dropSequence.sqf
+++ b/addons/supply_drop/functions/fnc_dropSequence.sqf
@@ -29,6 +29,8 @@ _heli flyInHeight 100;
 [{
     params ["_heliGroup", "_heli", "_crate"];
 
+    _crate allowDamage false;
+
     _heli setSlingLoad objNull;
 
     private _smoke = "SmokeShellOrange" createVehicle position _crate;


### PR DESCRIPTION
**When merged this pull request will:**

- title. set `allowDamage` to `false` for crate object once dropped from helicopter, since sometimes crates catch fire and are destroyed at varying altitudes on ground impact

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
