### PR TITLE
Loot - Improve / QoL

### DIFF
--- a/addons/loot/CfgEventHandlers.hpp
+++ b/addons/loot/CfgEventHandlers.hpp
@@ -7,6 +7,7 @@ class Extended_PreInit_EventHandlers {
 class Extended_PostInit_EventHandlers {
     class ADDON {
         serverInit = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+        Init = QUOTE(call COMPILE_SCRIPT(XEH_clientInit));
     };
 };
 

--- a/addons/loot/XEH_clientInit.sqf
+++ b/addons/loot/XEH_clientInit.sqf
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+if (!hasInterface) exitWith {};
+
+// Grab nearby building positions in 100m and cache them as used so no loot generates infront of player on spawn / reload inside buildings
+[{!isNull player}, {
+    [player, 100] call EFUNC(common,nearBuilding) params ["", "", "_nearBuildings"];
+    private _toCache = [];
+
+    {
+        _toCache pushBackUnique _x;
+    } forEach _nearBuildings;
+
+    GVAR(building_used) append _toCache;
+
+    publicVariableServer QGVAR(building_used);
+}, []] call CBA_fnc_waitUntilAndExecute;

--- a/addons/loot/XEH_preInit.sqf
+++ b/addons/loot/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+GVAR(building_used) = [];
+
 #include "XEH_PREP.hpp"
 
 #include "initSettings.inc.sqf"

--- a/addons/loot/functions/fnc_loop.sqf
+++ b/addons/loot/functions/fnc_loop.sqf
@@ -14,8 +14,6 @@
  *
 */
 
-if (!GVAR(enabled)) exitWith {};
-
 private _players = call EFUNC(common,listPlayers);
 
 // if no players in game, rerun loop after timedown

--- a/addons/loot/functions/fnc_parseData.sqf
+++ b/addons/loot/functions/fnc_parseData.sqf
@@ -16,8 +16,6 @@
 
 private _config = missionConfigFile >> "CfgMisery_LootData" >> "LootPool";
 
-GVAR(building_used) = [];
-
 GVAR(chance) = getNumber (_config >> "chance");
 GVAR(uniformItemChance) = getNumber (_config >> "uniformItemChance");
 GVAR(vestsItemChance) = getNumber (_config >> "vestsItemChance");


### PR DESCRIPTION
**When merged this pull request will:**
- title, fixed initial loot generation for players, removed loot spawning infront of them on initial spawn / reload (while inside buildings)

- removed loops enabled GVAR check, no setting for enabling loot exists anymore, since system is controlled by mission config data

- moved building_used GVAR to preInit to have the array ready before a client / the player loads

- added clientInit XEH, loads right after serverInit & immediately passes nearby building data to the server preventing the spawn issue

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
