### PR TITLE
Refuel | Repair Shops - Fixes

### DIFF
--- a/addons/refuel/functions/fnc_listed.sqf
+++ b/addons/refuel/functions/fnc_listed.sqf
@@ -31,7 +31,7 @@
     private _totalLiters = 0;
 
     {
-        if ((_x select 0) isEqualTo _nearestVehicle) then {
+        if ((_x select 0) isEqualTo typeOf _nearestVehicle) then {
             _found = true;
             private _fuelTypeIndex = _x select 1;
             _fuelCost = GVAR(fuelCosts) select _fuelTypeIndex;

--- a/addons/refuel/functions/fnc_process.sqf
+++ b/addons/refuel/functions/fnc_process.sqf
@@ -30,7 +30,7 @@ if (_nearestVehicle isEqualTo []) exitWith {};
 [_nearestVehicle] call EFUNC(common,getObjectData) params ["_displayName"];
 
 {
-    if ((_x select 0) isEqualTo _nearestVehicle) then {
+    if ((_x select 0) isEqualTo typeOf _nearestVehicle) then {
         _found = true;
         private _fuelTypeIndex = _x select 1;
         _fuelCost = GVAR(fuelCosts) select _fuelTypeIndex;

--- a/addons/refuel/ui/refuelShop.hpp
+++ b/addons/refuel/ui/refuelShop.hpp
@@ -61,7 +61,7 @@ class CLASS(refuelShop_ui) {
             colorBackground[] = {0.2, 0.2, 0.2, 0.7};
             colorFocused[] = {0.5, 0.5, 0.5, 0.7};
             colorActive[] = {0.5, 0.5, 0.5, 0.7};
-            onButtonClick = QUOTE([] call EFUNC(refuel,process));
+            onButtonClick = QUOTE([] call EFUNC(refuel,purchase));
         };
         class CLASS(refuelShop_exit): RscButton {
             idc = 1601;

--- a/addons/repair/functions/fnc_listed.sqf
+++ b/addons/repair/functions/fnc_listed.sqf
@@ -32,7 +32,7 @@
     private _found = false;
 
     {
-        if ((_x select 0) isEqualTo _nearestVehicle) then {
+        if ((_x select 0) isEqualTo typeOf _nearestVehicle) then {
             private _array = _x;
             _found = true;
             _repairPrice = _x select 3;

--- a/addons/repair/functions/fnc_process.sqf
+++ b/addons/repair/functions/fnc_process.sqf
@@ -29,7 +29,7 @@ if (_nearestVehicle isEqualTo []) exitWith {};
 [_nearestVehicle] call EFUNC(common,getObjectData) params ["_displayName"];
 
 {
-    if ((_x select 0) isEqualTo _nearestVehicle) then {
+    if ((_x select 0) isEqualTo typeOf _nearestVehicle) then {
         _found = true;
         _repairPrice = _x select 3;
     };
@@ -54,21 +54,21 @@ if (_funds < _repairPrice) exitWith {
     _dialog displayRemoveEventHandler ["KeyDown", _repairsInterrupt];
 };
 
-if (damage _nearestVehicle <= 0) exitWith {
-    private _displayFull = format ["%1 is already fully repaired...", _displayName];
-    ctrlSetText [1001, _displayFull];
+private _hitData = getAllHitPointsDamage _nearestVehicle;
+if (_hitData isEqualTo [] || {(_hitData select 2) findIf {_x > 0} isEqualTo -1}) exitWith {
+    ctrlSetText [1001, format ["%1 is already fully repaired...", _displayName]];
     [982386, [1600, 1601], true] call EFUNC(common,displayShowControls);
     player setVariable [QCLASS(processRepairs), nil];
     _dialog displayRemoveEventHandler ["KeyDown", _repairsInterrupt];
 };
 
 private _totalSteps = 100;
-private _repairStep = 1 / _totalSteps;
-private _fundsToDeduct = _repairPrice;
+private _repairStep = 0.05;
+private _fundsPerTick = _repairPrice / _totalSteps;
 
 [{
     params ["_args", "_handle"];
-    _args params ["_nearestVehicle", "_dialog", "_displayName", "_repairsInterrupt", "_repairStep", "_fundsToDeduct"];
+    _args params ["_nearestVehicle", "_dialog", "_displayName", "_repairsInterrupt", "_repairStep", "_fundsPerTick"];
 
     call EFUNC(common,getPlayerVariables) params ["", "", "", "", "", "", "", "", "", "", "", "", "", "_funds"];
 
@@ -78,7 +78,7 @@ private _fundsToDeduct = _repairPrice;
         _handle call CBA_fnc_removePerFrameHandler;
     };
 
-    if (_funds < _fundsToDeduct) exitWith {
+    if (_funds < _fundsPerTick) exitWith {
         player setVariable [QCLASS(processRepairs), nil];
         _dialog displayRemoveEventHandler ["KeyDown", _repairsInterrupt];
         ctrlSetText [1001, "You cannot afford this!"];
@@ -86,32 +86,38 @@ private _fundsToDeduct = _repairPrice;
         _handle call CBA_fnc_removePerFrameHandler;
     };
 
-    private _currentDamage = damage _nearestVehicle;
-    private _repairAmount = _repairStep min _currentDamage;
+    private _hitPoints = getAllHitPointsDamage _nearestVehicle;
+    private _names = _hitPoints select 0;
+    private _damages = _hitPoints select 2;
 
-    _nearestVehicle setDamage (_currentDamage - _repairAmount);
+    private _targetIndex = _damages findIf { _x > 0 };
+
+    if (_targetIndex isEqualTo -1) exitWith {
+        player setVariable [QCLASS(processRepairs), nil];
+        _dialog displayRemoveEventHandler ["KeyDown", _repairsInterrupt];
+        ctrlSetText [1001, format ["%1 has been fully repaired...", _displayName]];
+        [982386, [1600, 1601], true] call EFUNC(common,displayShowControls);
+        _handle call CBA_fnc_removePerFrameHandler;
+    };
+
+    private _partName = _names select _targetIndex;
+    private _partDamage = _damages select _targetIndex;
+    private _newDamage = (_partDamage - _repairStep) max 0;
+
+    [_nearestVehicle, [_partName, _newDamage]] remoteExecCall ["setHitPointDamage", _nearestVehicle];
+
+    [-_fundsPerTick] call EFUNC(currency,modifyMoney);
 
     private _displayedText = format [
-        "Repairing...%1%2%1Repair progress: %3%4 Funds:%1%5%1%6",
+        "Repairing %2...%1Fixing: %3%1Funds: %4 %5",
         endl,
         _displayName,
-        (1 - (_currentDamage - _repairAmount)) * 100 toFixed 2,
-        "%",
+        _partName,
         EGVAR(currency,symbol),
         [_funds, 1, 2, true] call CBA_fnc_formatNumber
     ];
     ctrlSetText [1001, _displayedText];
 
-    [-_fundsToDeduct] call EFUNC(currency,modifyMoney);
-
-    if (damage _nearestVehicle <= 0) exitWith {
-        player setVariable [QCLASS(processRepairs), nil];
-        _dialog displayRemoveEventHandler ["KeyDown", _repairsInterrupt];
-        private _displayFull = format ["%1 has been fully repaired...", _displayName];
-        ctrlSetText [1001, _displayFull];
-        [982386, [1600, 1601], true] call EFUNC(common,displayShowControls);
-        _handle call CBA_fnc_removePerFrameHandler;
-    };
-}, 0.5, [
-    _nearestVehicle, _dialog, _displayName, _repairsInterrupt, _repairStep, _fundsToDeduct
+}, 0.2, [
+_nearestVehicle, _dialog, _displayName, _repairsInterrupt, _repairStep, _fundsPerTick
 ]] call CBA_fnc_addPerFrameHandler;

--- a/addons/repair/ui/repairShop.hpp
+++ b/addons/repair/ui/repairShop.hpp
@@ -61,7 +61,7 @@ class CLASS(repairShop_ui) {
             colorBackground[] = {0.2, 0.2, 0.2, 0.7};
             colorFocused[] = {0.5, 0.5, 0.5, 0.7};
             colorActive[] = {0.5, 0.5, 0.5, 0.7};
-            onButtonClick = QUOTE([] call EFUNC(repair,process));
+            onButtonClick = QUOTE([] call EFUNC(repair,purchase));
         };
         class CLASS(repairShop_exit): RscButton {
             idc = 1601;


### PR DESCRIPTION
**When merged this pull request will:**
- fixed data retrieval for repair and refuel shops, updated nearestVehicle data grab to grab classname data rather than varname value to reference vehicle data table from classnames

- improved repair shop to drain funds and use hitpoint damage over regualr damage, repairs are processed through each hitpoint of the vehicle

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
