### PR TITLE
Maintenance - Fix Vehicle info ui

### DIFF
--- a/addons/maintenance/functions/fnc_vehicleStats.sqf
+++ b/addons/maintenance/functions/fnc_vehicleStats.sqf
@@ -16,8 +16,6 @@
  * Public: No
 */
 
-showHUD [true, false, true, true, true, true, true, true, true, true, true];
-
 [{
     params ["_args", "_handle"];
 
@@ -41,28 +39,17 @@ showHUD [true, false, true, true, true, true, true, true, true, true, true];
 
     if (!alive player || isNull objectParent player) exitWith {
         QGVAR(display) cutText ["", "PLAIN"];
-        showHUD [true, true, true, true, true, true, true, true, true, true, true];
         _handle call CBA_fnc_removePerFrameHandler;
-    };
-
-    if (gunner _vehicle isEqualTo player || commander _vehicle isEqualTo player) then {
-        showHUD [true, true, true, true, true, true, true, true, true, true, true];
-    } else {
-        showHUD [true, false, true, true, true, true, true, true, true, true, true];
     };
 
     private _display = uiNamespace getVariable [QGVAR(vehicleStats_ui), objNull];
 
-    private _vehicleNameCtrl = _display displayCtrl 1000;
-    private _fuelBar = _display displayCtrl 1801;
     private _powerBar = _display displayCtrl 1802;
     private _oilBar = _display displayCtrl 1803;
     private _coolantIcon = _display displayCtrl 1100;
     private _coolantBar = _display displayCtrl 1804;
-    private _vehicleSpeedCtrl = _display displayCtrl 1001;
     private _batteryCtrl = _display displayCtrl 1002;
 
-    private _fuelLevel = fuel _vehicle;
     private _batteryLevel = _vehicle getVariable [QGVAR(batteryLevel), 0];
     private _batteryType = _vehicle getVariable [QGVAR(batteryType), nil];
     private _requiredBatteries = _vehicle getVariable [QGVAR(batteryCount), 0];
@@ -71,7 +58,6 @@ showHUD [true, false, true, true, true, true, true, true, true, true, true];
     private _installedBatteries = _vehicle getVariable [QGVAR(installedBatteries), 0];
 
     private _found = false;
-    private _fuelLiters = 0;
     private _coolantLiters = 0;
     private _batteryCount = 0;
     private _oilLiters = 0;
@@ -80,7 +66,6 @@ showHUD [true, false, true, true, true, true, true, true, true, true, true];
         if ((_x select 0) isEqualTo typeOf _vehicle) then {
             _array = _x;
             _found = true;
-            _fuelLiters = _x select 2;
             _coolantLiters = _x select 7;
             _batteryCount = _x select 6;
             _oilLiters = _x select 8;
@@ -91,9 +76,7 @@ showHUD [true, false, true, true, true, true, true, true, true, true, true];
 
     [_vehicle, _batteryType, _requiredBatteries] call FUNC(getBatteryCharge) params ["_totalCharge", "_maxCharge"];
 
-    _vehicleNameCtrl ctrlSetText format ["%1", _displayName];
     _batteryCtrl ctrlSetText format ["(Batteries: %1/%2)", _installedBatteries, _requiredBatteries];
-    _fuelBar progressSetPosition _fuelLevel;
     _powerBar progressSetPosition (_totalCharge / _maxCharge);
     _oilBar progressSetPosition _oilLevel;
     _coolantBar progressSetPosition _coolantLevel;
@@ -103,11 +86,6 @@ showHUD [true, false, true, true, true, true, true, true, true, true, true];
             {
                 _display displayCtrl _x ctrlShow false;
             } forEach [1802, 2001, 1002];
-        };
-        case (_fuelLiters isEqualTo 0): {
-            {
-                _display displayCtrl _x ctrlShow false;
-            } forEach [1801, 2000];
         };
         case (_oilLiters isEqualTo 0): {
             {
@@ -120,14 +98,6 @@ showHUD [true, false, true, true, true, true, true, true, true, true, true];
             } forEach [1804, 2003];
         };
     };
-
-    private _speedType = ["MPH:", "Km/h:"] select GVAR(speedType);
-    private _speedValue = [round (abs (speed _vehicle) * 0.6214), round (abs speed _vehicle)] select GVAR(speedType);
-
-    private _speedText = format ["%1 %2", _speedType, [_speedValue, 1, 0, false] call CBA_fnc_formatNumber];
-
-    _vehicleSpeedCtrl ctrlSetText _speedText;
-
 }, 0] call CBA_fnc_addPerFrameHandler;
 
 

--- a/addons/maintenance/initSettings.inc.sqf
+++ b/addons/maintenance/initSettings.inc.sqf
@@ -1,15 +1,6 @@
 private _category = format ["Misery - %1", QUOTE(COMPONENT_BEAUTIFIED)];
 
 [
-    QGVAR(speedType),
-    "CHECKBOX",
-    ["Speed display", "True - KM/H | False - MPH"],
-    _category,
-    false,
-    2
-] call CBA_fnc_addSetting;
-
-[
     QGVAR(difficulty),
     "CHECKBOX",
     ["Easier maintenance", "When enabled maintenance doesn't require as many parts for repairs"],

--- a/addons/maintenance/ui/vehicleStats.hpp
+++ b/addons/maintenance/ui/vehicleStats.hpp
@@ -16,26 +16,6 @@ class CLASS(vehicleStats_ui) {
         };
     };
     class Controls {
-        class CLASS(vehicle_name): RscText {
-            idc = 1000;
-            text = ""; //--- ToDo: Localize;
-            x = 42.5 * GUI_GRID_W + GUI_GRID_X;
-            y = 26 * GUI_GRID_H + GUI_GRID_Y;
-            w = 10.5 * GUI_GRID_W;
-            h = 2 * GUI_GRID_H;
-            font = UI_MACRO_FONT;
-            sizeEx = UI_MACRO_TEXTSIZE;
-        };
-        class CLASS(vehicle_fuelIcon): RscText {
-            idc = 2000;
-            text = QUOTE(Fuel:);
-            x = 42.5 * GUI_GRID_W + GUI_GRID_X;
-            y = 29 * GUI_GRID_H + GUI_GRID_Y;
-            w = 4.5 * GUI_GRID_W;
-            h = 1 * GUI_GRID_H;
-            font = UI_MACRO_FONT;
-            sizeEx = UI_MACRO_TEXTSIZE;
-        };
         class CLASS(vehicle_powerIcon): RscText {
             idc = 2001;
             text = QUOTE(Power:);
@@ -66,13 +46,6 @@ class CLASS(vehicleStats_ui) {
             font = UI_MACRO_FONT;
             sizeEx = UI_MACRO_TEXTSIZE;
         };
-        class CLASS(vehicle_fuelProgressBar): CLASS(RscProgress) {
-            idc = 1801;
-            x = 47 * GUI_GRID_W + GUI_GRID_X;
-            y = 29.5 * GUI_GRID_H + GUI_GRID_Y;
-            w = 5 * GUI_GRID_W;
-            h = 0.5 * GUI_GRID_H;
-        };
         class CLASS(vehicle_powerProgressBar): CLASS(RscProgress) {
             idc = 1802;
             x = 47 * GUI_GRID_W + GUI_GRID_X;
@@ -93,16 +66,6 @@ class CLASS(vehicleStats_ui) {
             y = 32.5 * GUI_GRID_H + GUI_GRID_Y;
             w = 5 * GUI_GRID_W;
             h = 0.5 * GUI_GRID_H;
-        };
-        class CLASS(vehicle_speed): RscText {
-            idc = 1001;
-            text = ""; //--- ToDo: Localize;
-            x = 57 * GUI_GRID_W + GUI_GRID_X;
-            y = 31.5 * GUI_GRID_H + GUI_GRID_Y;
-            w = 7.5 * GUI_GRID_W;
-            h = 2 * GUI_GRID_H;
-            font = UI_MACRO_FONT;
-            sizeEx = UI_MACRO_TEXTSIZE;
         };
         class CLASS(vehicle_batteries): RscText {
             idc = 1002;


### PR DESCRIPTION
**When merged this pull request will:**
- removed vehicle name data

- removed speed value

- removed fuel info

- made the maintenance ui much more simplified since the vanilla vehicle info hud already does much of the heavy lifting, also removing certain elements actually breaks some displays

- removed `showHUD` changes

- removed speed option in `initSettings`

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
