### PR TITLE
Ambient AI | POI - Improve AI recruitment

### DIFF
--- a/addons/ambient_ai/XEH_PREP.hpp
+++ b/addons/ambient_ai/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(addGearOption);
 PREP(addRecruitOption);
 PREP(clean);
 PREP(convertToArray);

--- a/addons/ambient_ai/functions/fnc_addGearOption.sqf
+++ b/addons/ambient_ai/functions/fnc_addGearOption.sqf
@@ -1,0 +1,42 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Ambient AI gear option
+ * Adds gear interaction to spawned units matching players side SP only
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_ambient_ai_fnc_addGearOption;
+ *
+ * Public: No
+*/
+
+params ["_unit"];
+
+if (side _unit isEqualTo side player) then {
+
+    private _gearAction = [
+        QGVAR(gear_menu),
+        localize LSTRING(OpenInventory),
+        QUOTE(a3\ui_f_curator\data\rsccommon\rscattributeinventory\filter_10_ca.paa),
+        {
+            params ["_target", "_player"];
+            _target action ["Gear", objNull];
+        },
+        {
+            params ["_target", "_player"];
+            alive _target && (group _target isEqualTo group _player) && !(isPlayer _target);
+        },
+        {},
+        [],
+        [0, 0, 0],
+        3
+    ] call ACEFUNC(interact_menu,createAction);
+
+    [_unit, 0, [QUOTE(ACE_MainActions)], _gearAction] call ACEFUNC(interact_menu,addActionToObject);
+};

--- a/addons/ambient_ai/functions/fnc_addRecruitOption.sqf
+++ b/addons/ambient_ai/functions/fnc_addRecruitOption.sqf
@@ -2,10 +2,10 @@
 /*
  * Author: TenuredCLOUD
  * Ambient AI recruit option
- * Adds recruitment hold interaction to spawned units matching players side SP only
+ * Adds recruitment interaction to spawned units matching players side SP only
  *
  * Arguments:
- * None
+ * 0: Unit <OBJECT>
  *
  * Return Value:
  * None
@@ -23,34 +23,31 @@ if (side _unit isEqualTo side player) then {
     private _recruitmentCost = 500 * round (_equipmentMass * 100);
     private _unitIdentity = name _unit;
 
-    [
-        _unit,
-        format [localize LSTRING(RecruitUnit), _unitIdentity, EGVAR(money,symbol), [_recruitmentCost, 1, 2, true] call CBA_fnc_formatNumber],
-        "\a3\Ui_F_Oldman\Data\IGUI\Cfg\HoldActions\holdAction_market_ca.paa",
-        "\a3\Ui_F_Oldman\Data\IGUI\Cfg\HoldActions\holdAction_market_ca.paa",
-        "_this distance _target < 3",
-        "_caller distance _target < 3",
-        {},
-        {},
+    private _recruitAction = [
+        QGVAR(recruit_menu),
+        format [localize LSTRING(RecruitUnit), _unitIdentity, EGVAR(currency,symbol), [_recruitmentCost, 1, 2, true] call CBA_fnc_formatNumber],
+        QPATHTOEF(markers,data\hand_coins_ca.paa),
         {
-            params ["_target", "_caller", "_actionId", "_arguments"];
-            private _recruitmentCost = _arguments select 0;
-            private _unitIdentity = _arguments select 1;
-            private _playerMoney = _caller getVariable QCLASS(currency);
-            if (_playerMoney >= _recruitmentCost) then {
+            params ["_target", "_player", "_params"];
+            _params params ["_recruitmentCost", "_unitIdentity"];
+            call EFUNC(common,getPlayerVariables) params ["", "", "", "", "", "", "", "", "", "", "", "", "", "_funds"];
+            if (_funds >= _recruitmentCost) then {
                 [-_recruitmentCost] call EFUNC(currency,modifyMoney);
-                [_target] joinSilent _caller;
-                [_target,_actionId] call BIS_fnc_holdActionRemove;
-                [QEGVAR(common,tileText), format [localize LSTRING(RecruitUnit_Success), _unitIdentity, EGVAR(money,symbol), [_recruitmentCost, 1, 2, true] call CBA_fnc_formatNumber]] call CBA_fnc_localEvent;
+                [_target] joinSilent _player;
+                [QEGVAR(common,tileText), format [localize LSTRING(RecruitUnit_Success), name _target, EGVAR(currency,symbol), [_recruitmentCost, 1, 2, true] call CBA_fnc_formatNumber]] call CBA_fnc_localEvent;
             } else {
-                [QEGVAR(common,tileText), format [localize LSTRING(RecruitUnit_Fail),_unitIdentity]] call CBA_fnc_localEvent;
+                [QEGVAR(common,tileText), format [localize LSTRING(RecruitUnit_Fail), name _target]] call CBA_fnc_localEvent;
             };
+        },
+        {
+            params ["_target", "_player"];
+            alive _target && (group _target isNotEqualTo group _player);
         },
         {},
         [_recruitmentCost, _unitIdentity],
-        0.1,
-        nil,
-        false,
-        false
-    ] call BIS_fnc_holdActionAdd;
+        [0, 0, 0],
+        3
+    ] call ACEFUNC(interact_menu,createAction);
+
+    [_unit, 0, [QUOTE(ACE_MainActions)], _recruitAction] call ACEFUNC(interact_menu,addActionToObject);
 };

--- a/addons/ambient_ai/functions/fnc_spawn.sqf
+++ b/addons/ambient_ai/functions/fnc_spawn.sqf
@@ -85,8 +85,11 @@ for "_i" from 1 to _numEntities do {
 
     [_unit] call FUNC(randomGear);
 
+    [_unit, _unit] call ACEFUNC(common,claim);
+
     if !(isMultiplayer) then {
         [_unit] call FUNC(addRecruitOption);
+        [_unit] call FUNC(addGearOption);
     };
 
     _unit setVariable [QGRADGVAR(persistence,isExcluded), true];

--- a/addons/ambient_ai/stringtable.xml
+++ b/addons/ambient_ai/stringtable.xml
@@ -625,6 +625,22 @@
             <Chinesesimp>东方 / 红方</Chinesesimp>
             <Turkish>Doğu / OPFOR</Turkish>
         </Key>
+        <Key ID="STR_MISERY_Ambient_AI_OpenInventory">
+            <English>Open inventory</English>
+            <Czech>Otevřít inventář</Czech>
+            <French>Ouvrir l'inventaire</French>
+            <Spanish>Abrir inventario</Spanish>
+            <Italian>Apri inventario</Italian>
+            <Polish>Otwórz ekwipunek</Polish>
+            <Portuguese>Abrir inventário</Portuguese>
+            <Russian>Открыть инвентарь</Russian>
+            <German>Inventar öffnen</German>
+            <Korean>인벤토리 열기</Korean>
+            <Japanese>インベントリを開く</Japanese>
+            <Chinese>打開背包 / 打開物品欄</Chinese>
+            <Chinesesimp>打开背包 / 打开物品栏</Chinesesimp>
+            <Turkish>Envanteri aç</Turkish>
+        </Key>
         <Key ID="STR_MISERY_Ambient_AI_PrimaryWeapons">
             <English>Primary weapons</English>
             <Czech>Primární zbraně</Czech>

--- a/addons/poi/functions/fnc_generate.sqf
+++ b/addons/poi/functions/fnc_generate.sqf
@@ -251,6 +251,13 @@ if (_aiClass isNotEqualTo "") then {
         _unit setSkill ["aimingShake", _aiShake];
         _unit setSkill ["aimingSpeed", _aiSpeed];
 
+        [_unit, _unit] call ACEFUNC(common,claim);
+
+        if !(isMultiplayer) then {
+            [_unit] call EFUNC(ambient_ai,addRecruitOption);
+            [_unit] call EFUNC(ambient_ai,addGearOption);
+        };
+
         if ([50] call EFUNC(common,rollChance)) then {_unit action ["sitDown", _unit];};
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- moved recruitment option to ACE interaction vs older hold interaction (I missed it with initial ACE integration)

- added open gear interaction to recruited units

- made it so POI units if they match the player's side they can be recruited

- added "open inventory" string localization

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
