### PR TITLE
Temperature | Radiation - Fix Swimming conditions & Add Radioactive water option

### DIFF
--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -377,16 +377,6 @@ QCLASS(guttingKnife), \
 #define SICKNESS_FACTOR 1.6666667e-2 //0.5
 #define WETNESS_RATE 5e-4 //0.015
 
-// Swimming animations:
-#define MACRO_ANIMATION_SWIMMING \
-"asswpercmstpsnonwnondnon", \
-"aswmpercmrunsnonwnondl", \
-"asswpercmrunsnonwnondr", \
-"asswpercmrunsnonwnondb", \
-"asswpercmrunsnonwnondf", \
-"asswpercmrunsnonwnondf", \
-"aswmpercmrunsnonwnondfl"
-
 // IMS animations for compat:
 #define MACRO_ANIMATION_IMS_SPRINT "am_kulak_sprintf", "melee_sprintf", "melee_sprintfl", "melee_sprintfr"
 

--- a/addons/radiation/functions/fnc_inArea.sqf
+++ b/addons/radiation/functions/fnc_inArea.sqf
@@ -27,11 +27,12 @@ if !(call FUNC(checkAreas)) exitWith {
     {
         private _player = _x;
         private _isPlayerHandled = _player getVariable [QGVAR(insideArea), false];
+        private _isSwimming = [_player] call ACEFUNC(common,isSwimming);
 
         if (!_isPlayerHandled) then {
             private _isInsideZone = GVAR(areas) findIf {_player inArea _x} isNotEqualTo -1;
 
-            if (_isInsideZone || rain > 0) then {
+            if (_isInsideZone || rain > 0 || _isSwimming) then {
                 _player setVariable [QGVAR(insideArea), true, true];
                 [QGVAR(radiationEvent), [], _player] call CBA_fnc_targetEvent;
             };

--- a/addons/radiation/functions/fnc_process.sqf
+++ b/addons/radiation/functions/fnc_process.sqf
@@ -77,7 +77,7 @@
     if (GVAR(radioactiveWater)) then {
 
         if (_isSwimming) then {
-            _waterDose = 0.0005;
+            _waterDose = linearConversion [0, 3, _baseEffectiveDose, 0, 0.0005, true];
         };
     };
 

--- a/addons/radiation/functions/fnc_process.sqf
+++ b/addons/radiation/functions/fnc_process.sqf
@@ -45,9 +45,11 @@
 
     private _zoneDose = 0;
     private _rainDose = 0;
+    private _waterDose = 0;
 
     private _activeAreaIndex = GVAR(areas) findIf {player inArea _x};
     private _insideRadZone = _activeAreaIndex isNotEqualTo -1;
+    private _isSwimming = [player] call ACEFUNC(common,isSwimming);
 
     if (_insideRadZone) then {
         private _marker = GVAR(areas) select _activeAreaIndex;
@@ -72,7 +74,14 @@
         };
     };
 
-    private _totalDose = (_zoneDose + _rainDose) * _radResistance;
+    if (GVAR(radioactiveWater)) then {
+
+        if (_isSwimming) then {
+            _waterDose = 0.0005;
+        };
+    };
+
+    private _totalDose = (_zoneDose + _rainDose + _waterDose) * _radResistance;
 
     if (_totalDose > 0) then {
         [_totalDose, "radiation"] call EFUNC(common,addStatusModifier);
@@ -82,8 +91,9 @@
     [QUOTE(COMPONENT_BEAUTIFIED), format ["Total Effective Dose: %1 (Zone: %2, Rain: %3)", _totalDose, _zoneDose, _rainDose]] call EFUNC(common,debugMessage);
 
     private _isSafeFromRain = (rain < 0.1) || (_rainDose isEqualTo 0 && !_insideRadZone);
+    private _isSafeFromWater = (!_isSwimming) || (_waterDose isEqualTo 0 && !_insideRadZone);
 
-    if (!_insideRadZone && _isSafeFromRain) exitWith {
+    if (!_insideRadZone && _isSafeFromRain && _isSafeFromWater) exitWith {
         player setVariable [QGVAR(insideArea), false, true];
         _handle call CBA_fnc_removePerFrameHandler;
     };

--- a/addons/radiation/initSettings.inc.sqf
+++ b/addons/radiation/initSettings.inc.sqf
@@ -17,3 +17,12 @@ private _category = format ["Misery %1", localize LSTRING(Component)];
     false,
     1
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(radioactiveWater),
+    "CHECKBOX",
+    [LSTRING(RadioactiveWater), LSTRING(RadioactiveWaterDesc)],
+    _category,
+    false,
+    1
+] call CBA_fnc_addSetting;

--- a/addons/radiation/stringtable.xml
+++ b/addons/radiation/stringtable.xml
@@ -81,6 +81,38 @@
             <Chinesesimp>使能地图上会随机降下带有辐射强度的酸雨/辐射雨</Chinesesimp>
             <Turkish>Radyoaktif yağmuru etkinleştirir</Turkish>
         </Key>
+        <Key ID="STR_MISERY_Radiation_RadioactiveWater">
+            <English>Enable Radioactive waters</English>
+            <Czech>Povolit radioaktivní vodu</Czech>
+            <French>Activer les eaux radioactives</French>
+            <Spanish>Activar aguas radiactivas</Spanish>
+            <Italian>Abilita acque radioattive</Italian>
+            <Polish>Włącz radioaktywne wody</Polish>
+            <Portuguese>Ativar águas radioativas</Portuguese>
+            <Russian>Включить радиоактивную воду</Russian>
+            <German>Radioaktive Gewässer aktivieren</German>
+            <Korean>방사능 오염수 활성화</Korean>
+            <Japanese>放射能汚染水を有効化</Japanese>
+            <Chinese>啟用放射性水域</Chinese>
+            <Chinesesimp>启用放射性水域</Chinesesimp>
+            <Turkish>Radyoaktif Suları Etkinleştir</Turkish>
+        </Key>
+        <Key ID="STR_MISERY_Radiation_RadioactiveWaterDesc">
+            <English>Enables radioactive water when swimming</English>
+            <Czech>Aktivuje radioaktivitu vody při plavání</Czech>
+            <French>Active la radioactivité de l'eau lors de la nage</French>
+            <Spanish>Hace que el agua sea radiactiva al nadar</Spanish>
+            <Italian>Rende l'acqua radioattiva durante il nuoto</Italian>
+            <Polish>Sprawia, że woda jest radioaktywna podczas pływania</Polish>
+            <Portuguese>Torna a água radioativa ao nadar</Portuguese>
+            <Russian>Игрок получает радиацию во время плавания</Russian>
+            <German>Aktiviert radioaktive Strahlung beim Schwimmen</German>
+            <Korean>수영할 때 방사능 피해를 입습니다</Korean>
+            <Japanese>泳いでいる時に放射線ダメージを受けるようになります</Japanese>
+            <Chinese>游泳時會受到放射性輻射傷害</Chinese>
+            <Chinesesimp>游泳时会受到放射性辐射伤害</Chinesesimp>
+            <Turkish>Yüzerken radyoaktif suya maruz kalmayı etkinleştirir</Turkish>
+        </Key>
         <Key ID="STR_MISERY_Radiation_StoreArtifact">
             <English>Store Artifact</English>
             <Czech>Uložit artefakt</Czech>

--- a/addons/temperature/functions/fnc_coldPack.sqf
+++ b/addons/temperature/functions/fnc_coldPack.sqf
@@ -26,11 +26,11 @@ private _currentTimer = 0;
     params ["_args", "_handle"];
     _args params ["_currentTimer"];
 
-    private _isSwimming = (animationState player in [MACRO_ANIMATION_SWIMMING]);
+    private _isSwimming = [player] call ACEFUNC(common,isSwimming);
 
     if (isGamePaused) exitWith {};
 
-    if (isNull objectParent player && surfaceIsWater getPosWorld player || _isSwimming) exitWith {
+    if (isNull objectParent player && _isSwimming) exitWith {
         GVAR(thermalPackColdActive) = false;
         _handle call CBA_fnc_removePerFrameHandler;
     };

--- a/addons/temperature/functions/fnc_core.sqf
+++ b/addons/temperature/functions/fnc_core.sqf
@@ -30,6 +30,7 @@ private _targetExposure = _ambientTarget;
 private _thermalIndexModifier = _airTemp + (_clothesWarmth / 5);
 private _wetnessModifier = 0;
 private _changeMultiplier = 1;
+private _hasWetsuit = ((toLower uniform player) find "wetsuit") > -1;
 
 call EFUNC(common,nearFire) params ["", "_isInflamed"];
 
@@ -111,13 +112,12 @@ switch (true) do {
         };
     };
     default {
-        private _hasWetsuit = ((toLower uniform player) find "wetsuit") > -1;
-        private _isSwimming = (animationState player in [MACRO_ANIMATION_SWIMMING]);
+        private _isSwimming = [player] call ACEFUNC(common,isSwimming);
 
         private _rainWet = false;
         private _waterWet = false;
 
-        if (surfaceIsWater getPosWorld player || _isSwimming) then {
+        if (_isSwimming) then {
             _waterWet = true;
             _thermalIndexModifier = _seaTemp;
             _targetExposure = linearConversion [TEMP_MIN, TEMP_MAX, _seaTemp, -1, 1, true];
@@ -145,7 +145,7 @@ switch (true) do {
 private _driftChange = NEUTRAL_RATE * _changeMultiplier;
 private _exposureModifier = (_targetExposure - _exposure) * _driftChange;
 
-if (_wetness > 0 && _thermalIndex < TEMP_NEUTRAL) then {
+if (_wetness > 0 && _thermalIndex < TEMP_NEUTRAL && !_hasWetsuit) then {
     _exposureModifier = (_exposureModifier - (_wetness * WETNESS_RATE * 5)) * (3 + _wetness);
 };
 

--- a/addons/temperature/functions/fnc_heatPack.sqf
+++ b/addons/temperature/functions/fnc_heatPack.sqf
@@ -26,11 +26,11 @@ private _currentTimer = 0;
     params ["_args", "_handle"];
     _args params ["_currentTimer"];
 
-    private _isSwimming = (animationState player in [MACRO_ANIMATION_SWIMMING]);
+    private _isSwimming = [player] call ACEFUNC(common,isSwimming);
 
     if (isGamePaused) exitWith {};
 
-    if (isNull objectParent player && surfaceIsWater getPosWorld player || _isSwimming) exitWith {
+    if (isNull objectParent player && _isSwimming) exitWith {
         GVAR(thermalPackHeatActive) = false;
         _handle call CBA_fnc_removePerFrameHandler;
     };

--- a/addons/temperature/functions/fnc_thermalKit.sqf
+++ b/addons/temperature/functions/fnc_thermalKit.sqf
@@ -26,11 +26,11 @@ private _currentTimer = 0;
     params ["_args", "_handle"];
     _args params ["_currentTimer"];
 
-    private _isSwimming = (animationState player in [MACRO_ANIMATION_SWIMMING]);
+    private _isSwimming = [player] call ACEFUNC(common,isSwimming);
 
     if (isGamePaused) exitWith {};
 
-    if (isNull objectParent player && surfaceIsWater getPosWorld player || _isSwimming) exitWith {
+    if (isNull objectParent player && _isSwimming) exitWith {
         GVAR(thermalBagActive) = false;
         _handle call CBA_fnc_removePerFrameHandler;
     };


### PR DESCRIPTION
**When merged this pull request will:**
- removed swimming animations macro in `main`

- changed swimming check to utilize ACE's isSwimming func

- removed `surfaceIsWater` checks, since you could still get drenched just standing on a dock over a body of water...

- fixed wetsuits not protecting from exposure while being drenched / soaked from the rain etc...

- added Radioactive water options to `radiation` component

- added new strings fro radioactive water settings

- tweaked processor for new radioactive water setting

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
