### PR TITLE
Loot - GRAD fortifications Loot Fix

### DIFF
--- a/addons/loot/XEH_PREP.hpp
+++ b/addons/loot/XEH_PREP.hpp
@@ -4,6 +4,7 @@ PREP(checkAreas);
 PREP(generate);
 PREP(loop);
 PREP(parseData);
+PREP(parseGradFortData);
 PREP(parseSearchData);
 PREP(searchCondition);
 PREP(searchInteraction);

--- a/addons/loot/XEH_postInit.sqf
+++ b/addons/loot/XEH_postInit.sqf
@@ -5,6 +5,9 @@ if (!isServer) exitWith {};
 if (isClass (missionConfigFile >> "CfgMisery_LootData")) then {
     [{CBA_missionTime > 1}, {
         call FUNC(parseData);
+        if (isClass (missionConfigFile >> "CfgGradFortifications")) then {
+            call FUNC(parseGradFortData);
+        };
         call FUNC(checkAreas);
 
         [{

--- a/addons/loot/functions/fnc_loop.sqf
+++ b/addons/loot/functions/fnc_loop.sqf
@@ -31,11 +31,9 @@ if (_players isEqualTo []) exitWith {
     {
         private _building = _x;
         private _buildingType = typeOf _building;
-        //if (_buildingType in GVAR(buildingBlacklist) || _building in GVAR(building_used) || GVAR(areas) findIf {_building inArea _x} isNotEqualTo -1) exitWith {continue};
 
         if (_buildingType in GVAR(buildingBlacklist)) exitWith {continue};
         if (_building in GVAR(building_used)) exitWith {continue};
-        if (vehicleVarName _building in EGVAR(furniture,registeredPlacement)) exitWith {continue};
         if (GVAR(areas) isNotEqualTo [] && GVAR(areas) findIf { _building inArea _x } isNotEqualTo -1) exitWith {continue};
 
         private _buildingPositions = _building buildingPos -1;

--- a/addons/loot/functions/fnc_parseGradFortData.sqf
+++ b/addons/loot/functions/fnc_parseGradFortData.sqf
@@ -1,0 +1,26 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Fortifications data parser / retrieval from description.ext for CfgGradFortifications class
+ * Compat data for GRAD Fortifications module
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_loot_fnc_parseGradFortData;
+ *
+*/
+
+{
+    private _className = configName _x;
+
+    GVAR(buildingBlacklist) pushBack _className;
+
+} forEach ("true" configClasses (missionConfigFile >> "CfgGradFortifications" >> "Fortifications"));
+
+publicVariable QGVAR(buildingBlacklist);
+


### PR DESCRIPTION
**When merged this pull request will:**
- added GRAD fortification data parser for class retrieval for used forts, classes are then auto parsed into the building blacklist to remove loot spawning in them while being placed and after placement

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
