### PR TITLE
Fuel - Fix restrictions

### DIFF
--- a/addons/fuel/functions/fnc_initRefuelRestrictions.sqf
+++ b/addons/fuel/functions/fnc_initRefuelRestrictions.sqf
@@ -19,7 +19,7 @@
     private _pumpAllowedFuels = _source getVariable [QGVAR(fuelTypeSupported), []];
 
     // If target is a generator & source isn't jetfuel allow refilling
-    if (_target in EGVAR(power,generators) && 0 in _pumpAllowedFuels || 1 in _pumpAllowedFuels) exitWith {};
+    if (typeOf _target in EGVAR(power,generators) && [0, 1] in [_pumpAllowedFuels]) exitWith {};
 
     if (_pumpAllowedFuels isNotEqualTo []) then {
 
@@ -57,7 +57,7 @@
                 case 2: { _reqString = localize LSTRING(JetFuel) };
             };
 
-            private _msg = format [localize LSTRING(PumpSupports), _pumpAllowedFuels joinString " + ", _reqString];
+            private _msg = format [localize LSTRING(PumpDoesNotDispense), _reqString];
             [[_msg, 1, [1, 1, 1, 1]], [], true] call CBA_fnc_notify;
         };
     };

--- a/addons/fuel/stringtable.xml
+++ b/addons/fuel/stringtable.xml
@@ -113,22 +113,6 @@
             <Chinesesimp>泵未分配 %1...</Chinesesimp>
             <Turkish>Pompa %1 dağıtmıyor...</Turkish>
         </Key>
-        <Key ID="STR_MISERY_Fuel_PumpSupports">
-            <English>Pump supports: %1 Vehicle requires: %2</English>
-            <Czech>Čerpadlo podporuje: %1 Vozidlo vyžaduje: %2</Czech>
-            <French>La pompe fournit : %1 Le véhicule nécessite : %2</French>
-            <Spanish>La bomba admite: %1 El vehículo requiere: %2</Spanish>
-            <Italian>La pompa eroga: %1 Il veicolo richiede: %2</Italian>
-            <Polish>Pompa obsługuje: %1 Pojazd wymaga: %2</Polish>
-            <Portuguese>A bomba suporta: %1 O veículo requer: %2</Portuguese>
-            <Russian>Насос поддерживает: %1 Транспорту требуется: %2</Russian>
-            <German>Pumpe unterstützt: %1 Fahrzeug benötigt: %2</German>
-            <Korean>펌프 지원: %1 차량 요구: %2</Korean>
-            <Japanese>ポンプの対応: %1 車両の要求: %2</Japanese>
-            <Chinese>幫浦支援: %1 車輛需要: %2</Chinese>
-            <Chinesesimp>泵支持: %1 车辆需要: %2</Chinesesimp>
-            <Turkish>Pompa desteği: %1 Araç gereksinimi: %2</Turkish>
-        </Key>
         <Key ID="STR_MISERY_Fuel_RefillFuelCanAtPump">
             <English>Refill fuel can at pump</English>
             <Czech>Napleněte nádrž na pompe</Czech>


### PR DESCRIPTION
**When merged this pull request will:**
- title, fixed bad logic for early leaving of fuel listener for ACE refuel

- fixed notifier prompt when fuel pump can't be used on certain vehicles

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
