### PR TITLE
Loot - Fix searchable positioning checks

### DIFF
--- a/addons/loot/functions/fnc_cacheSearched.sqf
+++ b/addons/loot/functions/fnc_cacheSearched.sqf
@@ -4,7 +4,7 @@
  * Caches searched object position to array
  *
  * Arguments:
- * 0: Object <OBJECT>
+ * 0: Position <ARRAY>
  *
  * Return Value:
  * None
@@ -14,16 +14,14 @@
  *
 */
 
-params ["_object"];
+params ["_position"];
 
-private _position = getPosWorld _object;
-
-// Check if position is already cached (within 0.4 meters)
-if (GVAR(searchedPositions) findIf {_x distance _position < 0.4} isEqualTo -1) then {
+// Check if position is already cached (within 0.5 meters)
+if (GVAR(searchedPositions) findIf {_x vectorDistance _position < 0.5} isEqualTo -1) then {
 
     GVAR(searchedPositions) pushBack _position;
 
     publicVariable QGVAR(searchedPositions);
 
-    [QUOTE(COMPONENT_BEAUTIFIED), format ["Cached searched position %1 for object %2", _position, _object]] call EFUNC(common,debugMessage);
+    [QUOTE(COMPONENT_BEAUTIFIED), format ["Cached searched position %1", _position]] call EFUNC(common,debugMessage);
 };

--- a/addons/loot/functions/fnc_searchInteraction.sqf
+++ b/addons/loot/functions/fnc_searchInteraction.sqf
@@ -37,12 +37,14 @@
                 QPATHTOEF(icons,data\scan_search_ca.paa),
                 {
                     params ["", "", "_params"];
-                    _params params ["_realObject", "_objectData"];
-                    [_realObject, _objectData] call FUNC(searchObject);
+                    _params params ["_realObject", "_objectData", "_hitPos"];
+                    [_realObject, _objectData, _hitPos] call FUNC(searchObject);
                 },
                 {true},
                 {},
-                [_object, _objectData]
+                [_object, _objectData, _hitPos],
+                [0, 0, 0],
+                3
             ] call ACEFUNC(interact_menu,createAction);
 
             [GVAR(activeLogic), 0, [], _action] call ACEFUNC(interact_menu,addActionToObject);

--- a/addons/loot/functions/fnc_searchObject.sqf
+++ b/addons/loot/functions/fnc_searchObject.sqf
@@ -6,6 +6,7 @@
  * Arguments:
  * 0: Object <OBJECT>
  * 1: Object data <ARRAY>
+ * 2: Hit Position <ARRAY>
  *
  * Return Value:
  * None
@@ -15,7 +16,7 @@
  *
 */
 
-params ["_object", "_objectData"];
+params ["_object", "_objectData", "_hitPos"];
 
 if (isNull _object) exitWith {};
 
@@ -28,8 +29,7 @@ private _magazines = _objectData select 6;
 private _items = _objectData select 7;
 private _backpacks = _objectData select 8;
 
-private _pos = getPosWorld _object;
-if (GVAR(searchedPositions) findIf {_x distance _pos < 0.4} isNotEqualTo -1) exitWith {
+if (GVAR(searchedPositions) findIf {_x vectorDistance _hitPos < 0.5} isNotEqualTo -1) exitWith {
     [QEGVAR(common,tileText), localize LSTRING(AlreadySearched)] call CBA_fnc_localEvent;
 };
 
@@ -64,18 +64,18 @@ if (_audio isNotEqualTo "") then {
     {true},
     {
         params ["_args"];
-        _args params ["_object", "_objectData", "_soundDummy"];
+        _args params ["_object", "_objectData", "_hitPos", "_soundDummy"];
         private _searchChance = _objectData select 2;
         private _weapons = _objectData select 5;
         private _magazines = _objectData select 6;
         private _items = _objectData select 7;
         private _backpacks = _objectData select 8;
 
+        [_hitPos] call FUNC(cacheSearched);
+
         if (_soundDummy isNotEqualTo objNull) then {
             deleteVehicle _soundDummy;
         };
-
-        [_object] call FUNC(cacheSearched);
 
         if ([_searchChance] call EFUNC(common,rollChance)) exitWith {
             [QEGVAR(common,tileText), localize LSTRING(NothingFound)] call CBA_fnc_localEvent;
@@ -123,7 +123,7 @@ if (_audio isNotEqualTo "") then {
     },
     {
         params ["_args"];
-        _args params ["_object", "_objectData", "_soundDummy"];
+        _args params ["_object", "_objectData", "_hitPos", "_soundDummy"];
         private _searchChance = _objectData select 2;
         private _weapons = _objectData select 5;
         private _magazines = _objectData select 6;
@@ -136,5 +136,5 @@ if (_audio isNotEqualTo "") then {
             deleteVehicle _soundDummy;
         };
     },
-    [_object, _objectData, _soundDummy]
+    [_object, _objectData, _hitPos, _soundDummy]
 ] call CBA_fnc_progressBar;


### PR DESCRIPTION
**When merged this pull request will:**
- title, removed position grabbing from the object being interacted with, now grabs position of intersection point returning true world positions and not model positions

- increased distance to used positions check to 0.5m

- changed `distance` checks to `vectorDistance` for cached searched points

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
