### PR TITLE
Supply Drops - Fix events running in main menu

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -64,6 +64,14 @@ GVAR(defaultLoadout) = [[[],[],[],[],[],[],"","",[],["ItemMap","","","ItemCompas
     systemChat format ["[%1] %2", _callsign, _text];
 }] call CBA_fnc_addEventHandler;
 
+[QGVAR(radioBroadcastAudio), {
+    params ["_sound"];
+
+    if !([[MACRO_RADIOS]] call EFUNC(common,hasItem)) exitWith {};
+
+    playSound _sound;
+}] call CBA_fnc_addEventHandler;
+
 [QGVAR(chromA), {
     params ["_duration", "_commitTime"];
     [_duration, _commitTime] call FUNC(chromaticEffect);

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 2
 #define MINOR 0
 #define PATCH 0
-#define BUILD 1
+#define BUILD 2

--- a/addons/supply_drop/XEH_postInit.sqf
+++ b/addons/supply_drop/XEH_postInit.sqf
@@ -6,7 +6,7 @@ if (!GVAR(enabled)) exitWith {};
 GVAR(dropZones) = [];
 GVAR(activeDrops) = [];
 
-["CBA_settingsInitialized", {
+["CBA_loadingScreenDone", {
     [] call FUNC(convertToArray);
     [] call FUNC(loop);
     [] call FUNC(cleanCheck);

--- a/addons/supply_drop/functions/fnc_airSequence.sqf
+++ b/addons/supply_drop/functions/fnc_airSequence.sqf
@@ -47,6 +47,10 @@ _heliGroup move _dropZone;
     format [localize LSTRING(EnRoute), _dropZone]
 ]] call CBA_fnc_globalEvent;
 
+private _radioSound = selectRandom ["RadioAmbient2", "RadioAmbient8"];
+
+[QEGVAR(common,radioBroadcastAudio), [_radioSound]] call CBA_fnc_globalEvent;
+
 // Blacklist all objects from saving
 _heli setVariable [QGRADGVAR(persistence,isExcluded), true];
 _crate setVariable [QGRADGVAR(persistence,isExcluded), true];

--- a/addons/supply_drop/functions/fnc_dropSequence.sqf
+++ b/addons/supply_drop/functions/fnc_dropSequence.sqf
@@ -26,6 +26,9 @@ _heli flyInHeight 100;
     localize LSTRING(Dropping)
 ]] call CBA_fnc_globalEvent;
 
+private _radioSound = selectRandom ["RadioAmbient2", "RadioAmbient8"];
+[QEGVAR(common,radioBroadcastAudio), [_radioSound]] call CBA_fnc_globalEvent;
+
 [{
     params ["_heliGroup", "_heli", "_crate"];
 
@@ -55,6 +58,9 @@ _heli flyInHeight 100;
     groupId _heliGroup,
     localize LSTRING(Delivered)
     ]] call CBA_fnc_globalEvent;
+
+    private _radioSound = selectRandom ["RadioAmbient2", "RadioAmbient8"];
+    [QEGVAR(common,radioBroadcastAudio), [_radioSound]] call CBA_fnc_globalEvent;
 
     [{
         params ["_args", "_handle"];


### PR DESCRIPTION
**When merged this pull request will:**
- changed `CBA_settingsInitialized` event to `CBA_loadingScreenDone` event, drops should now only load after mission starts

- version bump to 2.0.0.2

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
