### PR TITLE
Chemical | Artifacts - Fix & Improve

### DIFF
--- a/addons/artifacts/functions/fnc_inArea.sqf
+++ b/addons/artifacts/functions/fnc_inArea.sqf
@@ -22,25 +22,31 @@ if !(call FUNC(checkAreas)) exitWith {
     params ["_args", "_handle"];
     {
         private _player = _x;
-        private _isPlayerHandled = _player getVariable [QGVAR(insideArea), false];
+        private _currentTrackingMarker = _player getVariable [QGVAR(insideArea), ""];
 
-        if (!_isPlayerHandled) then {
-            private _currentMarker = "";
-            {
-                if (_player inArea _x && {!(_x in GVAR(processedMarkers))}) exitWith {
-                _currentMarker = _x;
-                };
-            } forEach GVAR(areas);
+        private _markerPlayerIsInside = "";
+        {
+            if (_player inArea _x) exitWith {
+                _markerPlayerIsInside = _x;
+            };
+        } forEach GVAR(areas);
 
-            if (_currentMarker isNotEqualTo "") then {
-                _player setVariable [QGVAR(insideArea), true, true];
+        if (_markerPlayerIsInside isEqualTo "" && _currentTrackingMarker isNotEqualTo "") then {
+            _player setVariable [QGVAR(insideArea), "", true];
+        };
+
+        if (_markerPlayerIsInside isNotEqualTo "" && {_markerPlayerIsInside isNotEqualTo _currentTrackingMarker}) then {
+
+            _player setVariable [QGVAR(insideArea), _markerPlayerIsInside, true];
+
+            if !(_markerPlayerIsInside in GVAR(processedMarkers)) then {
                 [QGVAR(artifactSpawnEvent), [
-                    getMarkerPos _currentMarker,
-                    round(linearConversion [0, 500, selectMax (getMarkerSize _currentMarker), 5, 20, true]),
-                    selectMax (getMarkerSize _currentMarker),
-                    getMarkerSize _currentMarker,
-                    _currentMarker
-                ], _player] call CBA_fnc_targetEvent;
+                    getMarkerPos _markerPlayerIsInside,
+                    round(linearConversion [0, 500, selectMax (getMarkerSize _markerPlayerIsInside), 5, 20, true]),
+                    selectMax (getMarkerSize _markerPlayerIsInside),
+                    getMarkerSize _markerPlayerIsInside,
+                    _markerPlayerIsInside
+                ]] call CBA_fnc_globalEvent;
             };
         };
     } forEach (call EFUNC(common,listPlayers));

--- a/addons/artifacts/functions/fnc_spawn.sqf
+++ b/addons/artifacts/functions/fnc_spawn.sqf
@@ -29,13 +29,25 @@ if (_currentMarker in GVAR(processedMarkers)) exitWith {
 
 [_centerPos, _radius] call EFUNC(common,nearBuilding) params ["", "", "_nearBuildings"];
 
-private _buildingPositions = {
-    _x buildingPos -1;
+private _buildingPositions = [];
+
+{
+    _buildingPositions append (_x buildingPos -1);
 } forEach _nearBuildings;
 
 for "_i" from 1 to _numArtifacts do {
-    private _useBuilding = [50] call EFUNC(common,rollChance);
-    private _randomPos = [[_currentMarker] call CBA_fnc_randPosArea, selectRandom _buildingPositions] select _useBuilding;
+    private _useBuilding = [[50] call EFUNC(common,rollChance), false] select (_buildingPositions isEqualTo []);
+
+    private _randomPos = if (_useBuilding) then {
+        selectRandom _buildingPositions;
+    } else {
+        [_currentMarker] call CBA_fnc_randPosArea;
+    };
+
+    if (count _randomPos < 3) then {
+        _randomPos = [_currentMarker] call CBA_fnc_randPosArea;
+        _useBuilding = false;
+    };
 
     private _groundHolder = createVehicle ["WeaponHolderSimulated", _randomPos, [], 0, "CAN_COLLIDE"];
 

--- a/addons/chemical/functions/fnc_gas.sqf
+++ b/addons/chemical/functions/fnc_gas.sqf
@@ -17,21 +17,20 @@
 if (GVAR(initialColor) isEqualTo [0, 0, 0, 0] && GVAR(finalColor) isEqualTo [0, 0, 0, 0]) exitWith {};
 
 {
-private _marker = _x;
-private _markerSize = selectMax (getMarkerSize _x);
-private _position = getMarkerPos _x;
-private _fog1 = "#particlesource" createVehicleLocal _position;
-private _fog2 = "#particlesource" createVehicleLocal _position;
-private _fog3 = "#particlesource" createVehicleLocal _position;
+    private _marker = _x;
+    private _markerSize = selectMax (getMarkerSize _x);
+    private _position = getMarkerPos _x;
+    private _fog1 = "#particlesource" createVehicleLocal _position;
+    private _fog2 = "#particlesource" createVehicleLocal _position;
+    private _fog3 = "#particlesource" createVehicleLocal _position;
 
-{
-    _x setParticleParams [
-    ["\A3\Data_F\ParticleEffects\Universal\universal.p3d", 16, 12, 13, 0], "", "Billboard", 1, 10,
-    [0, 0, -6], [0, 0, 0], 1, 1.275, 1, 0,
-    [7, 6], [GVAR(initialColor), GVAR(finalColor)], [1000], 1, 0, "", "", _x];
-    _x setParticleRandom [4, [0, 0, 0.2], [0, 0, -0.1], 2, 1, [0, 0, 0, 0.1], 0, 0];
-    _x setParticleCircle [_markerSize / 2, [0, 0, -0.12]];
-    _x setDropInterval 0.035;
-} forEach [_fog1, _fog2, _fog3];
-
+    {
+        _x setParticleParams [
+        ["\A3\Data_F\ParticleEffects\Universal\universal.p3d", 16, 12, 13, 0], "", "Billboard", 1, 10,
+        [0, 0, -6], [0, 0, 0], 1, 1.275, 1, 0,
+        [7, 6], [GVAR(initialColor), GVAR(finalColor)], [1000], 1, 0, "", "", _x];
+        _x setParticleRandom [4, [_markerSize, _markerSize, 0.2], [0.5, 0.5, -0.1], 2, 1, [0, 0, 0, 0.1], 0, 0];
+        _x setParticleCircle [0, [0, 0, 0]];
+        _x setDropInterval 0.035;
+    } forEach [_fog1, _fog2, _fog3];
 } forEach GVAR(areas);

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -4,7 +4,7 @@
 #include "script_version.hpp"
 
 #define VERSION MAJOR.MINOR
-#define VERSION_AR MAJOR,MINOR,PATCH,BUILD
+#define VERSION_AR MAJOR,MINOR,PATCH
 
 #define REQUIRED_VERSION 2.18
 

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,3 @@
 #define MAJOR 2
 #define MINOR 0
-#define PATCH 0
-#define BUILD 2
+#define PATCH 3


### PR DESCRIPTION
**When merged this pull request will:**
- fixed chemical areas making a gas ring around the marker only rather than filling the center area of the marker

- fixed artifact spawner RPT spam error of holder placement

- fixed artifact spawner logic locking, new logic references the marker name while tracking players

- moved `artifact` spawn event to a `globalEvent` rather than a targeted event to players

- bump to version 2.0.3 (removed build versioning)

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
