### PR TITLE
Loot | Hydrology | Mining | Forestry | Sleep - Improve Interactions

### DIFF
--- a/addons/forestry/CfgEventHandlers.hpp
+++ b/addons/forestry/CfgEventHandlers.hpp
@@ -6,6 +6,6 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+        clientInit = QUOTE(call COMPILE_SCRIPT(XEH_clientInit));
     };
 };

--- a/addons/forestry/XEH_clientInit.sqf
+++ b/addons/forestry/XEH_clientInit.sqf
@@ -10,7 +10,24 @@ if !(hasInterface) exitWith {};
         params ["_type"];
         if (_type isNotEqualTo 0) exitWith {};
 
+        [ACE_player, 1, 2] call EFUNC(common,nearEnvironmentSource) params ["_found"];
+
+        if !(_found) exitWith {};
+
         [] call FUNC(interaction);
+    }] call CBA_fnc_addEventHandler;
+
+    [QCLASSACE(interactMenuClosed), {
+        if (!isNull GVAR(activeTreeLogic)) then {
+            [GVAR(activeTreeLogic), 0, [QUOTE(ACE_MainActions), QGVAR(forestryTree_Base_menu)]] call ACEFUNC(interact_menu,removeActionFromObject);
+            deleteVehicle GVAR(activeTreeLogic);
+            GVAR(activeTreeLogic) = objNull;
+        };
+        if (!isNull GVAR(activeForagingLogic)) then {
+            [GVAR(activeForagingLogic), 0, [QUOTE(ACE_MainActions), QGVAR(foraging_menu)]] call ACEFUNC(interact_menu,removeActionFromObject);
+            deleteVehicle GVAR(activeForagingLogic);
+            GVAR(activeForagingLogic) = objNull;
+        };
     }] call CBA_fnc_addEventHandler;
 
     private _forestrySplitLog = [

--- a/addons/forestry/functions/fnc_axeAction.sqf
+++ b/addons/forestry/functions/fnc_axeAction.sqf
@@ -16,14 +16,12 @@
  *
 */
 
-params ["_found", "_tree", "_damaged", "_hasAxe"];
+params ["_found", "_tree"];
+
+private _hasAxe = [[QCLASS(woodaxe), MACRO_AXES]] call EFUNC(common,hasItem);
 
 if !(_found) exitWith {
     [QEGVAR(common,tileText), format [localize LSTRING(NeedTreeChopping)]] call CBA_fnc_localEvent;
-};
-
-if (_damaged) exitWith {
-    [QEGVAR(common,tileText), format [localize LSTRING(TreeEmpty)]] call CBA_fnc_localEvent;
 };
 
 if !(_hasAxe) exitWith {

--- a/addons/forestry/functions/fnc_digForWorms.sqf
+++ b/addons/forestry/functions/fnc_digForWorms.sqf
@@ -24,7 +24,7 @@ if (GVAR(digPositions) findIf {_x distance getPosATL ACE_player < 2.5} isNotEqua
     [QEGVAR(common,tileText), localize LSTRING(AreaDug)] call CBA_fnc_localEvent;
 };
 
-[ACE_player, "Crouch", 1] call ACEFUNC(common,doAnimation);
+[ACE_player, "AinvPknlMstpSnonWnonDnon_medic4", 1] call ACEFUNC(common,doAnimation);
 
 if (currentWeapon ACE_player isNotEqualTo "") then {
     [ACE_player] call ACEFUNC(weaponselect,putWeaponAway);
@@ -52,9 +52,13 @@ if (currentWeapon ACE_player isNotEqualTo "") then {
 
         [QUOTE(COMPONENT_BEAUTIFIED), format ["Cached position %1 for worms", _position]] call EFUNC(common,debugMessage);
     };
+
+    [ACE_player, "", 1] call ACEFUNC(common,doAnimation);
 },
 {
     [QEGVAR(common,tileText), localize LSTRING(StopDigging)] call CBA_fnc_localEvent;
+
+    [ACE_player, "", 1] call ACEFUNC(common,doAnimation);
 },
 []
 ] call CBA_fnc_progressBar;

--- a/addons/forestry/functions/fnc_forageTreeAction.sqf
+++ b/addons/forestry/functions/fnc_forageTreeAction.sqf
@@ -6,7 +6,6 @@
  * Arguments:
  * 0: Found <BOOL>
  * 1: Tree <OBJECT>
- * 2: Damaged <BOOL>
  *
  * Return Value:
  * None
@@ -15,14 +14,10 @@
  *
 */
 
-params ["_found", "_tree", "_damaged"];
+params ["_found", "_tree"];
 
 if !(_found) exitWith {
     [QEGVAR(common,tileText), format [localize LSTRING(NeedTreeGathering)]] call CBA_fnc_localEvent;
-};
-
-if (_damaged) exitWith {
-    [QEGVAR(common,tileText), format [localize LSTRING(TreeEmpty)]] call CBA_fnc_localEvent;
 };
 
 if (GVAR(gatheredPositions) findIf {_x distance getPosATL ACE_player < 2.5} isNotEqualTo -1) exitWith {

--- a/addons/forestry/functions/fnc_interaction.sqf
+++ b/addons/forestry/functions/fnc_interaction.sqf
@@ -14,161 +14,129 @@
  *
 */
 
-[{
-    params ["_args", "_handle"];
+[ACE_player, 1, 2] call EFUNC(common,nearEnvironmentSource) params ["_found", "_tree", "_hitPos"];
 
-    if (!ACEGVAR(interact_menu,keydown)) exitWith {
-        [_handle] call CBA_fnc_removePerFrameHandler;
-        if (!isNull GVAR(activeTreeLogic)) then {
-            deleteVehicle GVAR(activeTreeLogic);
-            GVAR(activeTreeLogic) = objNull;
+if (_found) then {
+
+    if (isNull GVAR(activeTreeLogic)) then {
+        GVAR(activeTreeLogic) = "ACE_LogicDummy" createVehicleLocal [0, 0, 0];
+
+        GVAR(activeTreeLogic) setPosASL _hitPos;
+
+        private _baseAction = [
+            QGVAR(forestryTree_Base_menu),
+            localize ECSTRING(common,Interact),
+            QPATHTOEF(icons,data\trees_ca.paa),
+            {
+                params ["", "", "_params"];
+            },
+            {true},
+            {},
+            []
+        ] call ACEFUNC(interact_menu,createAction);
+
+        private _gatherWoodAction = [
+            QGVAR(forestryCollectWood_menu),
+            localize LSTRING(CollectWood),
+            "a3\ui_f\data\igui\cfg\actions\take_ca.paa",
+            {
+                params ["", "", "_params"];
+                _params params ["_found", "_tree"];
+                [_found, _tree] call FUNC(forageTreeAction);
+            },
+            {true},
+            {},
+            [_found, _tree]
+        ] call ACEFUNC(interact_menu,createAction);
+
+        private _axeAction = [
+            QGVAR(forestryChopWood_menu),
+            localize LSTRING(ChopDown),
+            QPATHTOEF(icons,data\axe_ca.paa),
+            {
+                params ["", "", "_params"];
+                _params params ["_found", "_tree"];
+                [_found, _tree] call FUNC(axeAction);
+            },
+            {
+                [[QCLASS(woodaxe), MACRO_AXES]] call EFUNC(common,hasItem)
+            },
+            {},
+            [_found, _tree]
+        ] call ACEFUNC(interact_menu,createAction);
+
+        private _sawAction = [
+            QGVAR(forestrySawWood_menu),
+            localize LSTRING(CutDown),
+            QPATHTOEF(icons,data\axe_ca.paa),
+            {
+                params ["", "", "_params"];
+                _params params ["_found", "_tree"];
+                [_found, _tree] call FUNC(sawAction);
+            },
+            {
+                [[QCLASS(chainsaw)]] call EFUNC(common,hasItem)
+            },
+            {},
+            [_found, _tree]
+        ] call ACEFUNC(interact_menu,createAction);
+
+        [GVAR(activeTreeLogic), 0, [QUOTE(ACE_MainActions)], _baseAction] call ACEFUNC(interact_menu,addActionToObject);
+
+        [GVAR(activeTreeLogic), 0, [QUOTE(ACE_MainActions), QGVAR(forestryTree_Base_menu)], _gatherWoodAction] call ACEFUNC(interact_menu,addActionToObject);
+
+        if (GVAR(choppingWood)) then {
+            [GVAR(activeTreeLogic), 0, [QUOTE(ACE_MainActions), QGVAR(forestryTree_Base_menu)], _axeAction] call ACEFUNC(interact_menu,addActionToObject);
         };
-        if (!isNull GVAR(activeForagingLogic)) then {
-            deleteVehicle GVAR(activeForagingLogic);
-            GVAR(activeForagingLogic) = objNull;
+
+        if (GVAR(sawingWood)) then {
+            [GVAR(activeTreeLogic), 0, [QUOTE(ACE_MainActions), QGVAR(forestryTree_Base_menu)], _sawAction] call ACEFUNC(interact_menu,addActionToObject);
         };
     };
 
-    [ACE_player] call EFUNC(common,nearTree) params ["_found", "_nearestTree", "_damaged", "_hasAxe", "_hasSaw"];
-
-    if (_found && {_nearestTree isNotEqualTo []}) then {
-
-        private _tree = _nearestTree select 0;
-
-        if (isNull GVAR(activeTreeLogic)) then {
-            GVAR(activeTreeLogic) = "ACE_LogicDummy" createVehicleLocal [0, 0, 0];
-
-            private _baseAction = [
-                QGVAR(forestryTree_Base_menu),
-                localize ECSTRING(common,Interact),
-                QPATHTOEF(icons,data\trees_ca.paa),
-                {
-                    params ["", "", "_params"];
-                },
-                {true},
-                {},
-                []
-            ] call ACEFUNC(interact_menu,createAction);
-
-            private _gatherWoodAction = [
-                QGVAR(forestryCollectWood_menu),
-                localize LSTRING(CollectWood),
-                "a3\ui_f\data\igui\cfg\actions\take_ca.paa",
-                {
-                    params ["", "", "_params"];
-                    _params params ["_found", "_tree", "_damaged"];
-                    [_found, _tree, _damaged] call FUNC(forageTreeAction);
-                },
-                {true},
-                {},
-                [_found, _tree, _damaged]
-            ] call ACEFUNC(interact_menu,createAction);
-
-            private _axeAction = [
-                QGVAR(forestryChopWood_menu),
-                localize LSTRING(ChopDown),
-                QPATHTOEF(icons,data\axe_ca.paa),
-                {
-                    params ["", "", "_params"];
-                    _params params ["_found", "_tree", "_damaged", "_hasAxe"];
-                    [_found, _tree, _damaged, _hasAxe] call FUNC(axeAction);
-                },
-                {
-                    [[QCLASS(woodaxe), MACRO_AXES]] call EFUNC(common,hasItem)
-                },
-                {},
-                [_found, _tree, _damaged, _hasAxe]
-            ] call ACEFUNC(interact_menu,createAction);
-
-            private _sawAction = [
-                QGVAR(forestrySawWood_menu),
-                localize LSTRING(CutDown),
-                QPATHTOEF(icons,data\axe_ca.paa),
-                {
-                    params ["", "", "_params"];
-                    _params params ["_found", "_tree", "_damaged", "_hasSaw"];
-                    [_found, _tree, _damaged, _hasSaw] call FUNC(sawAction);
-                },
-                {
-                    [[QCLASS(chainsaw)]] call EFUNC(common,hasItem)
-                },
-                {},
-                [_found, _tree, _damaged, _hasSaw]
-            ] call ACEFUNC(interact_menu,createAction);
-
-            [GVAR(activeTreeLogic), 0, [], _baseAction] call ACEFUNC(interact_menu,addActionToObject);
-
-            [GVAR(activeTreeLogic), 0, [QGVAR(forestryTree_Base_menu)], _gatherWoodAction] call ACEFUNC(interact_menu,addActionToObject);
-
-            if (GVAR(choppingWood)) then {
-                [GVAR(activeTreeLogic), 0, [QGVAR(forestryTree_Base_menu)], _axeAction] call ACEFUNC(interact_menu,addActionToObject);
-            };
-
-            if (GVAR(sawingWood)) then {
-                [GVAR(activeTreeLogic), 0, [QGVAR(forestryTree_Base_menu)], _sawAction] call ACEFUNC(interact_menu,addActionToObject);
-            };
-        };
-
-        if (isNull GVAR(activeForagingLogic)) then {
-            GVAR(activeForagingLogic) = "ACE_LogicDummy" createVehicleLocal [0, 0, 0];
-
-            if (GVAR(foraging)) then {
-
-                private _foragingMenu = [
-                    QGVAR(foraging_menu),
-                    localize LSTRING(Forage),
-                    QPATHTOEF(icons,data\leaf_ca.paa),
-                    {},
-                    {true}
-                ] call ACEFUNC(interact_menu,createAction);
-
-                private _foragingWormsMenu = [
-                    QGVAR(foragingWorms_menu),
-                    localize LSTRING(ForageDigForWorms),
-                    QPATHTOEF(icons,data\shovel_ca.paa),
-                    {
-                        [] call FUNC(digForWorms)
-                    },
-                    {true}
-                ] call ACEFUNC(interact_menu,createAction);
-
-                private _foragingTinderMenu = [
-                    QGVAR(foragingTinder_menu),
-                    localize LSTRING(ForageSearchForTinder),
-                    QPATHTOEF(icons,data\leaf_ca.paa),
-                    {
-                        [] call FUNC(searchForTinder)
-                    },
-                    {true}
-                ] call ACEFUNC(interact_menu,createAction);
-
-                [GVAR(activeForagingLogic), 0, [], _foragingMenu] call ACEFUNC(interact_menu,addActionToObject);
-
-                [GVAR(activeForagingLogic), 0, [QGVAR(foraging_menu)], _foragingWormsMenu] call ACEFUNC(interact_menu,addActionToObject);
-
-                [GVAR(activeForagingLogic), 0, [QGVAR(foraging_menu)], _foragingTinderMenu] call ACEFUNC(interact_menu,addActionToObject);
-            };
-        };
+    if (isNull GVAR(activeForagingLogic)) then {
+        GVAR(activeForagingLogic) = "ACE_LogicDummy" createVehicleLocal [0, 0, 0];
 
         private _treePos = getPosASL _tree;
-        private _playerPos = getPosASL ACE_player;
-
-        private _dirToPlayer = _treePos vectorFromTo _playerPos;
-
-        private _offsetPos = _treePos vectorAdd (_dirToPlayer vectorMultiply 0.5);
-        _offsetPos set [2, (_treePos select 2) + 1.2];
-
-        GVAR(activeTreeLogic) setPosASL _offsetPos;
 
         GVAR(activeForagingLogic) setPosASL _treePos;
-    } else {
-        if (!isNull GVAR(activeTreeLogic)) then {
-            deleteVehicle GVAR(activeTreeLogic);
-            GVAR(activeTreeLogic) = objNull;
-        };
-        if (!isNull GVAR(activeForagingLogic)) then {
-            deleteVehicle GVAR(activeForagingLogic);
-            GVAR(activeForagingLogic) = objNull;
+
+        if (GVAR(foraging)) then {
+
+            private _foragingMenu = [
+                QGVAR(foraging_menu),
+                localize LSTRING(Forage),
+                QPATHTOEF(icons,data\leaf_ca.paa),
+                {},
+                {true}
+            ] call ACEFUNC(interact_menu,createAction);
+
+            private _foragingWormsMenu = [
+                QGVAR(foragingWorms_menu),
+                localize LSTRING(ForageDigForWorms),
+                QPATHTOEF(icons,data\shovel_ca.paa),
+                {
+                    [] call FUNC(digForWorms)
+                },
+                {true}
+            ] call ACEFUNC(interact_menu,createAction);
+
+            private _foragingTinderMenu = [
+                QGVAR(foragingTinder_menu),
+                localize LSTRING(ForageSearchForTinder),
+                QPATHTOEF(icons,data\leaf_ca.paa),
+                {
+                    [] call FUNC(searchForTinder)
+                },
+                {true}
+            ] call ACEFUNC(interact_menu,createAction);
+
+            [GVAR(activeForagingLogic), 0, [QUOTE(ACE_MainActions)], _foragingMenu] call ACEFUNC(interact_menu,addActionToObject);
+
+            [GVAR(activeForagingLogic), 0, [QUOTE(ACE_MainActions), QGVAR(foraging_menu)], _foragingWormsMenu] call ACEFUNC(interact_menu,addActionToObject);
+
+            [GVAR(activeForagingLogic), 0, [QUOTE(ACE_MainActions), QGVAR(foraging_menu)], _foragingTinderMenu] call ACEFUNC(interact_menu,addActionToObject);
         };
     };
-}, 0] call CBA_fnc_addPerFrameHandler;
+};
+

--- a/addons/forestry/functions/fnc_sawAction.sqf
+++ b/addons/forestry/functions/fnc_sawAction.sqf
@@ -16,14 +16,12 @@
  *
 */
 
-params ["_found", "_tree", "_damaged", "_hasSaw"];
+params ["_found", "_tree"];
+
+private _hasSaw = [[QCLASS(chainsaw)]] call EFUNC(common,hasItem);
 
 if !(_found) exitWith {
     [QEGVAR(common,tileText), format [localize LSTRING(NeedTreeSawing)]] call CBA_fnc_localEvent;
-};
-
-if (_damaged) exitWith {
-    [QEGVAR(common,tileText), format [localize LSTRING(TreeEmpty)]] call CBA_fnc_localEvent;
 };
 
 if !(_hasSaw) exitWith {

--- a/addons/forestry/functions/fnc_searchForTinder.sqf
+++ b/addons/forestry/functions/fnc_searchForTinder.sqf
@@ -33,6 +33,8 @@ _soundDummy attachTo [ACE_player, [0, 0, 0], "Pelvis"];
 
 _soundDummy say3D [QCLASS(audio_sound_dryGrass), 25];
 
+[ACE_player, "AinvPknlMstpSnonWnonDnon_medic4", 1] call ACEFUNC(common,doAnimation);
+
 [localize LSTRING(SearchingTinder),
 15,
 {[ACE_player] call EFUNC(common,nearTree) params ["_found", "", "", "", ""]; _found},
@@ -62,6 +64,8 @@ _soundDummy say3D [QCLASS(audio_sound_dryGrass), 25];
 
         [QUOTE(COMPONENT_BEAUTIFIED), format ["Cached position %1 for tinder", _position]] call EFUNC(common,debugMessage);
     };
+
+    [ACE_player, "", 1] call ACEFUNC(common,doAnimation);
 },
 {
     params ["_args"];
@@ -72,6 +76,8 @@ _soundDummy say3D [QCLASS(audio_sound_dryGrass), 25];
     };
 
     [QEGVAR(common,tileText), localize LSTRING(StopSearchingTinder)] call CBA_fnc_localEvent;
+
+    [ACE_player, "", 1] call ACEFUNC(common,doAnimation);
 },
 [_nearestTree, _soundDummy]
 ] call CBA_fnc_progressBar;

--- a/addons/forestry/stringtable.xml
+++ b/addons/forestry/stringtable.xml
@@ -769,21 +769,5 @@
             <Chinesesimp>你停止了劈原木...</Chinesesimp>
             <Turkish>Kütüğü yarmayı bıraktınız...</Turkish>
         </Key>
-        <Key ID="STR_MISERY_Forestry_TreeEmpty">
-            <English>Tree has fallen, doesn't have anymore wood...</English>
-            <Czech>Strom padl, už v něm není žádné dřevo...</Czech>
-            <French>L'arbre est tombé, il n'y a plus de bois...</French>
-            <Spanish>El árbol ha caído, ya no tiene madera...</Spanish>
-            <Italian>L'albero è caduto, non ha più legna...</Italian>
-            <Polish>Drzewo upadło, nie ma już więcej drewna...</Polish>
-            <Portuguese>A árvore caiu, não tem mais madeira...</Portuguese>
-            <Russian>Дерево упало, в нем больше нет древесины...</Russian>
-            <German>Der Baum ist gefallen, er hat kein Holz mehr...</German>
-            <Korean>나무가 쓰러져 더 이상 목재가 없습니다...</Korean>
-            <Japanese>木が倒れました。もう木材はありません...</Japanese>
-            <Chinese>樹已經倒了，沒有更多木頭了...</Chinese>
-            <Chinesesimp>树已经倒了，没有更多木头了...</Chinesesimp>
-            <Turkish>Ağaç devrildi, artık odun yok...</Turkish>
-        </Key>
     </Package>
 </Project>

--- a/addons/hydrology/XEH_clientInit.sqf
+++ b/addons/hydrology/XEH_clientInit.sqf
@@ -27,21 +27,26 @@ if (isClass (missionConfigFile >> "CfgMisery_HydrologyData")) then {
     GVAR(lastInteractedSource) = objNull;
     GVAR(activeLogic) = objNull;
 
-    [QCLASSACE(interactMenuOpened), {
-        params ["_type"];
-        if (_type isNotEqualTo 0) exitWith {};
+    ["CBA_loadingScreenDone", {
 
-        [] call FUNC(condition) params ["_found"];
+        [QCLASSACE(interactMenuOpened), {
+            params ["_type"];
+            if (_type isNotEqualTo 0) exitWith {};
 
-        if !(_found) exitWith {};
+            [] call FUNC(condition) params ["_found"];
 
-        [] call FUNC(interaction);
-    }] call CBA_fnc_addEventHandler;
+            if !(_found) exitWith {};
 
-    [QCLASSACE(interactMenuClosed), {
-        if (!isNull GVAR(activeLogic)) then {
-            [GVAR(activeLogic), 0, [QGVAR(hydrology_menu)]] call ACEFUNC(interact_menu,removeActionFromObject);
-            GVAR(activeLogic) = objNull;
-        };
+            [] call FUNC(interaction);
+        }] call CBA_fnc_addEventHandler;
+
+        [QCLASSACE(interactMenuClosed), {
+            if (!isNull GVAR(activeLogic)) then {
+                [GVAR(activeLogic), 0, [QUOTE(ACE_MainActions), QGVAR(hydrology_menu)]] call ACEFUNC(interact_menu,removeActionFromObject);
+                [GVAR(activeLogic), 0, [QUOTE(ACE_MainActions), QGVAR(checkSource_menu)]] call ACEFUNC(interact_menu,removeActionFromObject);
+                deleteVehicle GVAR(activeLogic);
+                GVAR(activeLogic) = objNull;
+            };
+        }] call CBA_fnc_addEventHandler;
     }] call CBA_fnc_addEventHandler;
 };

--- a/addons/hydrology/XEH_postInit.sqf
+++ b/addons/hydrology/XEH_postInit.sqf
@@ -1,9 +1,9 @@
 #include "script_component.hpp"
 
+if (!isServer) exitWith {};
+
 if (isClass (missionConfigFile >> "CfgMisery_HydrologyData")) then {
-    if (isServer) then {
-        call FUNC(parseData);
-    };
+    call FUNC(parseData);
 } else {
     [QUOTE(COMPONENT_BEAUTIFIED), "CfgMisery_HydrologyData class not found in description.ext, skipping data parser..."] call EFUNC(common,debugMessage);
 };

--- a/addons/loot/XEH_clientInit.sqf
+++ b/addons/loot/XEH_clientInit.sqf
@@ -3,15 +3,42 @@
 if (!hasInterface) exitWith {};
 
 // Grab nearby building positions in 100m and cache them as used so no loot generates infront of player on spawn / reload inside buildings
-[{EGVAR(persistence,clientLoaded)}, {
-    [ACE_player, 100] call EFUNC(common,nearBuilding) params ["", "", "_nearBuildings"];
-    private _toCache = [];
+if (isClass (missionConfigFile >> "CfgMisery_LootData")) then {
+    [{EGVAR(persistence,clientLoaded)}, {
+        [ACE_player, 100] call EFUNC(common,nearBuilding) params ["", "", "_nearBuildings"];
+        private _toCache = [];
 
-    {
-        _toCache pushBackUnique _x;
-    } forEach _nearBuildings;
+        {
+            _toCache pushBackUnique _x;
+        } forEach _nearBuildings;
 
-    GVAR(building_used) append _toCache;
+        GVAR(building_used) append _toCache;
 
-    publicVariableServer QGVAR(building_used);
-}, []] call CBA_fnc_waitUntilAndExecute;
+        publicVariableServer QGVAR(building_used);
+    }, []] call CBA_fnc_waitUntilAndExecute;
+};
+
+if (isClass (missionConfigFile >> "CfgMisery_SearchableObjects")) then {
+
+    ["CBA_loadingScreenDone", {
+
+        [QCLASSACE(interactMenuOpened), {
+            params ["_type"];
+            if (_type isNotEqualTo 0) exitWith {};
+
+            [] call FUNC(searchCondition) params ["_found"];
+
+            if !(_found) exitWith {};
+
+            [] call FUNC(searchInteraction);
+        }] call CBA_fnc_addEventHandler;
+
+        [QCLASSACE(interactMenuClosed), {
+            if (!isNull GVAR(activeLogic)) then {
+                [GVAR(activeLogic), 0, [QUOTE(ACE_MainActions), QGVAR(searchObject_menu)]] call ACEFUNC(interact_menu,removeActionFromObject);
+                deleteVehicle GVAR(activeLogic);
+                GVAR(activeLogic) = objNull;
+            };
+        }] call CBA_fnc_addEventHandler;
+    }] call CBA_fnc_addEventHandler;
+};

--- a/addons/loot/XEH_postInit.sqf
+++ b/addons/loot/XEH_postInit.sqf
@@ -1,24 +1,12 @@
 #include "script_component.hpp"
 
+if (!isServer) exitWith {};
+
 if (isClass (missionConfigFile >> "CfgMisery_SearchableObjects")) then {
-
     [] call FUNC(parseSearchData);
-
-    [QCLASSACE(interactMenuOpened), {
-        params ["_type"];
-        if (_type isNotEqualTo 0) exitWith {};
-
-        [] call FUNC(searchCondition) params ["_found"];
-
-        if !(_found) exitWith {};
-
-        [] call FUNC(searchInteraction);
-    }] call CBA_fnc_addEventHandler;
 } else {
     [QUOTE(COMPONENT_BEAUTIFIED), "CfgMisery_SearchableObjects class not found in description.ext, skipping data parser..."] call EFUNC(common,debugMessage);
 };
-
-if (!isServer) exitWith {};
 
 if (isClass (missionConfigFile >> "CfgMisery_LootData")) then {
     [{CBA_missionTime > 1}, {

--- a/addons/loot/functions/fnc_searchCondition.sqf
+++ b/addons/loot/functions/fnc_searchCondition.sqf
@@ -17,7 +17,7 @@
  *
 */
 
-[1] call EFUNC(common,getLookedAtTarget) params ["_object", "_hitPos"];
+[2] call EFUNC(common,getLookedAtTarget) params ["_object", "_hitPos"];
 
 if (isNull _object) exitWith {[false, objNull, [], [0, 0, 0]]};
 

--- a/addons/loot/functions/fnc_searchInteraction.sqf
+++ b/addons/loot/functions/fnc_searchInteraction.sqf
@@ -13,49 +13,31 @@
  * [] call misery_loot_fnc_searchInteraction;
  *
 */
+[] call FUNC(searchCondition) params ["_found", "_object", "_objectData", "_hitPos"];
 
-[{
-    params ["_args", "_handle"];
-
-    if (!ACEGVAR(interact_menu,keydown)) exitWith {
-        [_handle] call CBA_fnc_removePerFrameHandler;
-        if (!isNull GVAR(activeLogic)) then {
-            deleteVehicle GVAR(activeLogic);
-            GVAR(activeLogic) = objNull;
-        };
-    };
-
-    [] call FUNC(searchCondition) params ["_found", "_object", "_objectData", "_hitPos"];
-
-    if (_found) then {
-        if (isNull GVAR(activeLogic)) then {
-            GVAR(activeLogic) = "ACE_LogicDummy" createVehicleLocal [0, 0, 0];
-
-            private _action = [
-                QGVAR(searchObject_menu),
-                localize LSTRING(SearchAction),
-                QPATHTOEF(icons,data\scan_search_ca.paa),
-                {
-                    params ["", "", "_params"];
-                    _params params ["_realObject", "_objectData", "_hitPos"];
-                    [_realObject, _objectData, _hitPos] call FUNC(searchObject);
-                },
-                {true},
-                {},
-                [_object, _objectData, _hitPos],
-                [0, 0, 0],
-                3
-            ] call ACEFUNC(interact_menu,createAction);
-
-            [GVAR(activeLogic), 0, [], _action] call ACEFUNC(interact_menu,addActionToObject);
-        };
+if (_found) then {
+    if (isNull GVAR(activeLogic)) then {
+        GVAR(activeLogic) = "ACE_LogicDummy" createVehicleLocal [0, 0, 0];
 
         GVAR(activeLogic) setPosASL _hitPos;
 
-    } else {
-        if (!isNull GVAR(activeLogic)) then {
-            deleteVehicle GVAR(activeLogic);
-            GVAR(activeLogic) = objNull;
-        };
+        private _action = [
+            QGVAR(searchObject_menu),
+            localize LSTRING(SearchAction),
+            QPATHTOEF(icons,data\scan_search_ca.paa),
+            {
+                params ["", "", "_params"];
+                _params params ["_realObject", "_objectData", "_hitPos"];
+                [_realObject, _objectData, _hitPos] call FUNC(searchObject);
+            },
+            {true},
+            {},
+            [_object, _objectData, _hitPos],
+            [0, 0, 0],
+            3
+        ] call ACEFUNC(interact_menu,createAction);
+
+        [GVAR(activeLogic), 0, [QUOTE(ACE_MainActions)], _action] call ACEFUNC(interact_menu,addActionToObject);
     };
-}, 0] call CBA_fnc_addPerFrameHandler;
+};
+

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -187,6 +187,7 @@
 "Land_WoodenBed_01_F", \
 "Land_Sun_chair_green_F", \
 "Land_ArmChair_01_F", \
+"Land_Sofa_01_F", \
 "Land_Sleeping_bag_F", \
 "Land_Sleeping_bag_blue_F", \
 "Land_Sleeping_bag_brown_F", \
@@ -218,6 +219,7 @@
 "woodenbed_01_f.p3d", \
 "sun_chair_green_f.p3d", \
 "armchair_01_f.p3d", \
+"sofa_01_f.p3d", \
 "sleeping_bag_f.p3d", \
 "sleeping_bag_blue_f.p3d", \
 "sleeping_bag_brown_f.p3d", \

--- a/addons/mining/XEH_clientInit.sqf
+++ b/addons/mining/XEH_clientInit.sqf
@@ -4,14 +4,25 @@ if (!hasInterface) exitWith {};
 
 if (isClass (missionConfigFile >> "CfgMisery_MiningData")) then {
 
-    [QCLASSACE(interactMenuOpened), {
-        params ["_type"];
-        if (_type isNotEqualTo 0) exitWith {};
+    ["CBA_loadingScreenDone", {
 
-        [] call FUNC(condition) params ["_found"];
+        [QCLASSACE(interactMenuOpened), {
+            params ["_type"];
+            if (_type isNotEqualTo 0) exitWith {};
 
-        if !(_found) exitWith {};
+            [] call FUNC(condition) params ["_found"];
 
-        [] call FUNC(interaction);
+            if !(_found) exitWith {};
+
+            [] call FUNC(interaction);
+        }] call CBA_fnc_addEventHandler;
+
+        [QCLASSACE(interactMenuClosed), {
+            if (!isNull GVAR(activeLogic)) then {
+                [GVAR(activeLogic), 0, [QUOTE(ACE_MainActions), QGVAR(mineOre_menu)]] call ACEFUNC(interact_menu,removeActionFromObject);
+                deleteVehicle GVAR(activeLogic);
+                GVAR(activeLogic) = objNull;
+            };
+        }] call CBA_fnc_addEventHandler;
     }] call CBA_fnc_addEventHandler;
 };

--- a/addons/sleep/XEH_PREP.hpp
+++ b/addons/sleep/XEH_PREP.hpp
@@ -1,3 +1,4 @@
 PREP(condition);
 PREP(hourSelected);
+PREP(interaction);
 PREP(processSleep);

--- a/addons/sleep/XEH_clientInit.sqf
+++ b/addons/sleep/XEH_clientInit.sqf
@@ -3,6 +3,7 @@
 if (isMultiplayer) exitWith {};
 
 ["CBA_loadingScreenDone", {
+
     private _sleepAction = [
         QGVAR(sleep_menu),
         localize LSTRING(Action),
@@ -11,9 +12,29 @@ if (isMultiplayer) exitWith {};
             createDialog QCLASS(sleepMenu_ui);
         },
         {
-            call FUNC(condition);
+            call FUNC(condition) select 0;
         }
     ] call ACEFUNC(interact_menu,createAction);
 
     [ACE_player, 1, [QUOTE(ACE_SelfActions)], _sleepAction] call ACEFUNC(interact_menu,addActionToObject);
+
+    [QCLASSACE(interactMenuOpened), {
+        params ["_type"];
+        if (_type isNotEqualTo 0) exitWith {};
+
+        [] call FUNC(condition) params ["", "_found"];
+
+        if !(_found) exitWith {};
+
+        [] call FUNC(interaction);
+    }] call CBA_fnc_addEventHandler;
+
+    [QCLASSACE(interactMenuClosed), {
+        if (!isNull GVAR(activeLogic)) then {
+            [GVAR(activeLogic), 0, [QUOTE(ACE_MainActions), QGVAR(sleepObject_menu)]] call ACEFUNC(interact_menu,removeActionFromObject);
+            deleteVehicle GVAR(activeLogic);
+            GVAR(activeLogic) = objNull;
+        };
+    }] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;
+

--- a/addons/sleep/XEH_preInit.sqf
+++ b/addons/sleep/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+GVAR(activeLogic) = objNull;
+
 #include "XEH_PREP.hpp"
 
 ADDON = true;

--- a/addons/sleep/functions/fnc_condition.sqf
+++ b/addons/sleep/functions/fnc_condition.sqf
@@ -7,30 +7,41 @@
  * None
  *
  * Return Value:
- * 0: Near bed object, or terrainObject, or ACE_player is in a ground vehicle, or cursorObject model matches bed model macro <BOOL>
+ * 0: Player in safe vehicle <BOOL>
+ * 1: Found <BOOL>
+ * 2: Sleeping Object <OBJECT>
+ * 3: Intersection position of looked at object <ARRAY>
  *
  * Example:
- * [] call misery_sleep_fnc_sleepCondition
+ * [] call misery_sleep_fnc_condition
  *
 */
 
-[2] call EFUNC(common,getLookedAtTarget) params ["_object"];
+[5] call EFUNC(common,getLookedAtTarget) params ["_object", "_hitPos"];
 
-private _modelInfo = "";
+if (isNull _object && isNull objectParent ACE_player) exitWith {[false, false, objNull, [0, 0, 0]]};
 
-if (!isNull _object) then {
-    _modelInfo = (getModelInfo _object) select 0;
+private _modelInfo = getModelInfo _object select 0;
+
+private _sleepingObject = objNull;
+
+private _index = [MACRO_BED_MODELS] findIf {_x isEqualTo _modelInfo};
+
+if (_index isNotEqualTo -1) then {
+    _sleepingObject = _object;
 };
+
+private _found = !isNull _sleepingObject;
 
 private _vehicleConfig = "";
 
 private _canSleepInVehicle = false;
 
 if !(isNull objectParent ACE_player) then {
-    _vehicleConfig = configOf (vehicle ACE_player);
+    _vehicleConfig = configOf (objectParent ACE_player);
     if (getNumber (_vehicleConfig >> "transportSoldier") > 1) then {
         _canSleepInVehicle = true;
     };
 };
 
-(vehicle ACE_player isKindOf "Car" && _canSleepInVehicle) || _modelInfo in [MACRO_BED_MODELS]
+[(objectParent ACE_player isKindOf "Car" && _canSleepInVehicle), _found, _sleepingObject, _hitPos]

--- a/addons/sleep/functions/fnc_interaction.sqf
+++ b/addons/sleep/functions/fnc_interaction.sqf
@@ -1,7 +1,7 @@
 #include "..\script_component.hpp"
 /*
  * Author: TenuredCLOUD
- * Add dynamic action to mining objects
+ * Add dynamic action to sleeping objects
  *
  * Arguments:
  * None
@@ -10,11 +10,11 @@
  * None
  *
  * Example:
- * [] call misery_mining_fnc_interaction;
+ * [] call misery_sleep_fnc_interaction;
  *
 */
 
-[] call FUNC(condition) params ["_found", "_miningObject", "_objectData", "_hitPos"];
+call FUNC(condition) params ["", "_found", "_sleepingObject", "_hitPos"];
 
 if (_found) then {
     if (isNull GVAR(activeLogic)) then {
@@ -23,17 +23,17 @@ if (_found) then {
         GVAR(activeLogic) setPosASL _hitPos;
 
         private _action = [
-            QGVAR(mineOre_menu),
+            QGVAR(sleepObject_menu),
             localize LSTRING(Action),
-            QPATHTOEF(icons,data\pickaxe_ca.paa),
+            QPATHTOEF(icons,data\bed_ca.paa),
             {
-                params ["", "", "_params"];
-                _params params ["_found", "_obj", "_data"];
-                [_found, _obj, _data] call FUNC(action);
+                createDialog QCLASS(sleepMenu_ui);
             },
             {true},
             {},
-            [_found, _miningObject, _objectData]
+            [],
+            [0, 0, 0],
+            5
         ] call ACEFUNC(interact_menu,createAction);
 
         [GVAR(activeLogic), 0, [QUOTE(ACE_MainActions)], _action] call ACEFUNC(interact_menu,addActionToObject);


### PR DESCRIPTION
**When merged this pull request will:**
- removed PFH for searchable loot ACE interaction, moved to ACE interact menu events

- removed PFH for mining ACE interactions, moved to ACE interact menu events

- fixed hydrology ACE interactions not getting removed and stacking

- removed PFH for forestry tree action, moved to interact menu events & changed from nearest search to hitPos with line Intersection

- improved sleep interaction, bed models now have a proper ace interaction, rather than relying on self interaction, same as other systems, event driven

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
