### PR TITLE
Currency - Gifting & Taking improvements

### DIFF
--- a/addons/ambient_ai/functions/fnc_addRecruitOption.sqf
+++ b/addons/ambient_ai/functions/fnc_addRecruitOption.sqf
@@ -33,6 +33,8 @@ if (side _unit isEqualTo side ACE_player) then {
             call EFUNC(common,getPlayerVariables) params ["", "", "", "", "", "", "", "", "", "", "", "", "", "_funds"];
             if (_funds >= _recruitmentCost) then {
                 [-_recruitmentCost] call EFUNC(currency,modifyMoney);
+                private _recipientFunds = _target getVariable [QEGVAR(currency,funds), MACRO_PLAYER_DEFAULTS_LOW];
+                _target setVariable [QEGVAR(currency,funds), _recipientFunds + _recruitmentCost, true];
                 [_target] joinSilent _player;
                 [QEGVAR(common,tileText), format [localize LSTRING(RecruitUnit_Success), name _target, EGVAR(currency,symbol), [_recruitmentCost, 1, 2, true] call CBA_fnc_formatNumber]] call CBA_fnc_localEvent;
             } else {

--- a/addons/ambient_ai/functions/fnc_spawn.sqf
+++ b/addons/ambient_ai/functions/fnc_spawn.sqf
@@ -113,6 +113,12 @@
         // Set var for money searching if chance exists
         if (EGVAR(currency,corpseHasMoneyChance) > 0) then {
             _unit setVariable [QEGVAR(currency,canSearch), true, true];
+            if ([EGVAR(currency,corpseHasMoneyChance)] call EFUNC(common,rollChance)) then {
+                private _cashFound = [EGVAR(currency,minAiMoney), EGVAR(currency,maxAiMoney)] call BIS_fnc_randomInt;
+                _unit setVariable [QEGVAR(currency,funds), _cashFound, true];
+            } else {
+                _unit setVariable [QEGVAR(currency,funds), 0, true];
+            };
         };
     };
 

--- a/addons/compat_wzc/functions/fnc_spawn.sqf
+++ b/addons/compat_wzc/functions/fnc_spawn.sqf
@@ -104,6 +104,17 @@
                 _unit enableDynamicSimulation true;
                 [_unit, _unit] call ACEFUNC(common,claim);
 
+                // Set var for money searching if chance exists (Only for regular zombies)
+                if (EGVAR(currency,corpseHasMoneyChance) > 0) then {
+                    _unit setVariable [QEGVAR(currency,canSearch), true, true];
+                    if ([EGVAR(currency,corpseHasMoneyChance)] call EFUNC(common,rollChance)) then {
+                        private _cashFound = [EGVAR(currency,minAiMoney), EGVAR(currency,maxAiMoney)] call BIS_fnc_randomInt;
+                        _unit setVariable [QEGVAR(currency,funds), _cashFound, true];
+                    } else {
+                        _unit setVariable [QEGVAR(currency,funds), 0, true];
+                    };
+                };
+
                 GVAR(registeredEntities) pushBack _group;
 
                 // set var for money searching if chance exists

--- a/addons/currency/XEH_PREP.hpp
+++ b/addons/currency/XEH_PREP.hpp
@@ -1,4 +1,6 @@
 PREP(bankRefresh);
+PREP(exitGifting);
+PREP(exitTaking);
 PREP(fundsDeposit);
 PREP(fundsWithdraw);
 PREP(generateBank);

--- a/addons/currency/XEH_postInit.sqf
+++ b/addons/currency/XEH_postInit.sqf
@@ -8,10 +8,13 @@ private _searchMoneyAction = [
         params ["_target", "_player"];
         createDialog QCLASS(moneyTake_ui);
         [_target] call FUNC(takeMoneyRefresh);
+        _player setVariable [QGVAR(searchTarget), _target];
     },
     {
         params ["_target", "_player"];
-        !alive _target && _target getVariable [QGVAR(canSearch), false];
+
+        private _isAwake = [_target] call ACEFUNC(common,isAwake);
+        (!_isAwake || _target getVariable [QACEGVAR(captives,isHandcuffed), false] || _target getVariable [QACEGVAR(captives,isSurrendering), false]) && _target getVariable [QGVAR(canSearch), false];
     },
     {},
     ["_target", "_player"],
@@ -29,6 +32,7 @@ private _giftMoneyAction = [
         params ["_target", "_player"];
         createDialog QCLASS(moneyGive_ui);
         [_target] call FUNC(giveMoneyRefresh);
+        _player setVariable [QGVAR(giftRecipient), getPlayerUID _target];
     },
     {
         params ["_target", "_player"];
@@ -58,26 +62,3 @@ private _player = [] call ACEFUNC(common,player);
 [_player, 1, [QUOTE(ACE_SelfActions), QUOTE(ACE_Equipment)], _fundsCheckAction] call ACEFUNC(interact_menu,addActionToObject);
 
 _player setVariable [QGVAR(canSearch), true, true];
-
-[QGVAR(addCorpseSearchAction), {
-    params ["_unit"];
-    if (isNull _unit) exitWith {};
-
-    [_unit, 0, [QUOTE(ACE_MainActions)], GVAR(searchForMoneyAction)] call ACEFUNC(interact_menu,addActionToObject);
-}] call CBA_fnc_addEventHandler;
-
-if (isServer) then {
-    ["CAManBase", "Killed", {
-        params ["_unit"];
-
-        if (!isPlayer _unit) then {
-            if ([GVAR(corpseHasMoneyChance)] call EFUNC(common,rollChance)) then {
-                private _midAiMoney = GVAR(minAiMoney) + GVAR(maxAiMoney) / 2;
-                private _cashFound = floor random [GVAR(minAiMoney), _midAiMoney, GVAR(maxAiMoney)];
-                _unit setVariable [QGVAR(funds), _cashFound, true];
-            } else {
-                _unit setVariable [QGVAR(funds), 0, true];
-            };
-        };
-    }] call CBA_fnc_addClassEventHandler;
-};

--- a/addons/currency/functions/fnc_exitGifting.sqf
+++ b/addons/currency/functions/fnc_exitGifting.sqf
@@ -1,0 +1,22 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Give Money UI exit
+ * Resets variables
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_currency_fnc_exitGifting;
+ *
+*/
+
+private _recipient = ACE_player getVariable [QGVAR(giftRecipient), ""];
+
+if (_recipient isNotEqualTo "") then {
+    ACE_player setVariable [QGVAR(giftRecipient), nil];
+};

--- a/addons/currency/functions/fnc_exitTaking.sqf
+++ b/addons/currency/functions/fnc_exitTaking.sqf
@@ -1,0 +1,22 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Take Money UI exit
+ * Resets variables
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_currency_fnc_exitTaking;
+ *
+*/
+
+private _target = ACE_player getVariable [QGVAR(searchTarget), objNull];
+
+if (_target isNotEqualTo objNull) then {
+    ACE_player setVariable [QGVAR(searchTarget), nil];
+};

--- a/addons/currency/functions/fnc_giveMoney.sqf
+++ b/addons/currency/functions/fnc_giveMoney.sqf
@@ -15,15 +15,17 @@
  *
 */
 
-[ACE_player, 2] call EFUNC(common,nearPlayer) params ["_isNear", "_targetPlayer"];
+private _targetUID = ACE_player getVariable [QGVAR(giftRecipient), ""];
 
 call EFUNC(common,getPlayerVariables) params ["", "", "", "", "", "", "", "", "", "", "", "", "", "_funds"];
 
-if (!_isNear) exitWith {
+private _recipient = _targetUID call BIS_fnc_getUnitByUID;
+
+if (isNull _recipient) exitWith {
     [QEGVAR(common,tileText), localize LSTRING(NoPlayer)] call CBA_fnc_localEvent;
 };
 
-private _targetPlayerFunds = _targetPlayer getVariable [QGVAR(funds), MACRO_PLAYER_DEFAULTS_LOW];
+private _recipientFunds = _recipient getVariable [QGVAR(funds), MACRO_PLAYER_DEFAULTS_LOW];
 
 private _amount = (ctrlText ((findDisplay 358493) displayCtrl 1400)) call BIS_fnc_parseNumber;
 
@@ -38,7 +40,7 @@ if (_amount > _funds) exitWith {
 [QEGVAR(common,tileText), format [localize LSTRING(Gifted), [_amount, 1, 2, true] call CBA_fnc_formatNumber, GVAR(symbol)]] call CBA_fnc_localEvent;
 
 // Increase target players money
-_targetPlayer setVariable [QGVAR(funds), _targetPlayerFunds + _amount, true];
+_recipient setVariable [QGVAR(funds), _recipientFunds + _amount, true];
 
 // Remove funds from player gifting
 [-_amount] call FUNC(modifyMoney);

--- a/addons/currency/functions/fnc_giveMoneyRefresh.sqf
+++ b/addons/currency/functions/fnc_giveMoneyRefresh.sqf
@@ -28,14 +28,12 @@ params ["_targetPlayer"];
 
         call EFUNC(common,getPlayerVariables) params ["", "", "", "", "", "", "", "", "", "", "", "", "", "_funds"];
 
-        private _targetPlayerFunds = _targetPlayer getVariable [QGVAR(funds), MACRO_PLAYER_DEFAULTS_LOW];
-
-        private _playerFundsParsed = _funds call BIS_fnc_parseNumber;
-        private _playerFundsFormatted = [_playerFundsParsed, 1, 2, true] call CBA_fnc_formatNumber;
+        private _playerFundsFormatted = [_funds, 1, 2, true] call CBA_fnc_formatNumber;
         private _playerFundsText = format ["%3: %1 %2", GVAR(symbol), _playerFundsFormatted, profileName];
 
-        private _targetPlayerFundsParsed = _targetPlayerFunds call BIS_fnc_parseNumber;
-        private _targetPlayerFundsFormatted = [_targetPlayerFundsParsed, 1, 2, true] call CBA_fnc_formatNumber;
+        private _targetPlayerFunds = _targetPlayer getVariable [QGVAR(funds), MACRO_PLAYER_DEFAULTS_LOW];
+
+        private _targetPlayerFundsFormatted = [_targetPlayerFunds, 1, 2, true] call CBA_fnc_formatNumber;
         private _targetPlayerFundsText = format ["%3: %1 %2", GVAR(symbol), _targetPlayerFundsFormatted, name _targetPlayer];
 
         ctrlSetText [1001, _targetPlayerFundsText];

--- a/addons/currency/functions/fnc_takeMoney.sqf
+++ b/addons/currency/functions/fnc_takeMoney.sqf
@@ -15,17 +15,17 @@
  *
 */
 
-[ACE_player, ["CAManBase"], 2] call EFUNC(common,nearCorpse) params ["_isNear", "_corpse"];
+private _target = ACE_player getVariable [QGVAR(searchTarget), objNull];
 
-if (!_isNear) exitWith {
+if (isNull _target) exitWith {
     [QEGVAR(common,tileText), localize LSTRING(NoCorpse)] call CBA_fnc_localEvent;
 };
 
-private _corpseFunds = _corpse getVariable [QGVAR(funds), MACRO_PLAYER_DEFAULTS_LOW];
+private _targetFunds = _target getVariable [QGVAR(funds), MACRO_PLAYER_DEFAULTS_LOW];
 
 private _amount = (ctrlText ((findDisplay 358492) displayCtrl 1400)) call BIS_fnc_parseNumber;
 
-if (_corpseFunds <= 0) exitWith {
+if (_targetFunds <= 0) exitWith {
     [QEGVAR(common,tileText), localize LSTRING(NoMoreFundsCorpse)] call CBA_fnc_localEvent;
 };
 
@@ -33,20 +33,20 @@ if (_amount <= 0) exitWith {
     [QEGVAR(common,tileText), localize LSTRING(InvalidAmount)] call CBA_fnc_localEvent;
 };
 
-if (_amount > _corpseFunds) exitWith {
-    [QEGVAR(common,tileText), format [localize LSTRING(Taken), [_corpseFunds, 1, 2, true] call CBA_fnc_formatNumber, GVAR(symbol)]] call CBA_fnc_localEvent;
+if (_amount > _targetFunds) exitWith {
+    [QEGVAR(common,tileText), format [localize LSTRING(Taken), [_targetFunds, 1, 2, true] call CBA_fnc_formatNumber, GVAR(symbol)]] call CBA_fnc_localEvent;
 
     // Deduct all of corpses money
-    _corpse setVariable [QGVAR(funds), _corpseFunds - _corpseFunds, true];
+    _target setVariable [QGVAR(funds), _targetFunds - _targetFunds, true];
 
     // Add profits to player
-    [_corpseFunds] call FUNC(modifyMoney);
+    [_targetFunds] call FUNC(modifyMoney);
 };
 
 [QEGVAR(common,tileText), format [localize LSTRING(Taken), [_amount, 1, 2, true] call CBA_fnc_formatNumber, GVAR(symbol)]] call CBA_fnc_localEvent;
 
 // Deduct corpses money
-_corpse setVariable [QGVAR(funds), _corpseFunds - _amount, true];
+_target setVariable [QGVAR(funds), _targetFunds - _amount, true];
 
 // Add profits to player
 [_amount] call FUNC(modifyMoney);

--- a/addons/currency/functions/fnc_takeMoneyRefresh.sqf
+++ b/addons/currency/functions/fnc_takeMoneyRefresh.sqf
@@ -4,7 +4,7 @@
  * Take money menu UI
  *
  * Arguments:
- * 0: Corpse <OBJECT>
+ * 0: Target <OBJECT>
  *
  * Return Value:
  * None
@@ -14,26 +14,22 @@
  *
 */
 
-params ["_corpse"];
+params ["_target"];
 
 [{!isNull findDisplay 358492}, {
-    params ["_corpse"];
+    params ["_target"];
     [{
         params ["_args", "_handle"];
-        _args params ["_corpse"];
+        _args params ["_target"];
 
         if (isNull findDisplay 358492) exitWith {
             _handle call CBA_fnc_removePerFrameHandler;
         };
 
-        call EFUNC(common,getPlayerVariables) params ["", "", "", "", "", "", "", "", "", "", "", "", "", "_funds"];
+        private _targetFunds = _target getVariable [QGVAR(funds), MACRO_PLAYER_DEFAULTS_LOW];
 
-        private _corpseFunds = _corpse getVariable [QGVAR(funds), MACRO_PLAYER_DEFAULTS_LOW];
+        private _targetFundsText = format [localize LSTRING(Funds), [_targetFunds, 1, 2, true] call CBA_fnc_formatNumber, GVAR(symbol)];
 
-        private _corpseFundsParsed = _corpseFunds call BIS_fnc_parseNumber;
-        private _corpseFundsFormatted = [_corpseFundsParsed, 1, 2, true] call CBA_fnc_formatNumber;
-        private _corpseFundsText = format ["%3: %1 %2", GVAR(symbol), _corpseFundsFormatted, localize LSTRING(Corpse)];
-
-        ctrlSetText [1001, _corpseFundsText];
-    }, 0.1, [_corpse]] call CBA_fnc_addPerFrameHandler;
-}, [_corpse]] call CBA_fnc_waitUntilAndExecute;
+        ctrlSetText [1001, _targetFundsText];
+    }, 0.1, [_target]] call CBA_fnc_addPerFrameHandler;
+}, [_target]] call CBA_fnc_waitUntilAndExecute;

--- a/addons/currency/stringtable.xml
+++ b/addons/currency/stringtable.xml
@@ -97,22 +97,6 @@
             <Chinesesimp>货币</Chinesesimp>
             <Turkish>Para Birimi</Turkish>
         </Key>
-        <Key ID="STR_MISERY_Currency_Corpse">
-            <English>Corpse</English>
-            <Czech>Mrtvola</Czech>
-            <French>Cadavre</French>
-            <Spanish>Cadáver</Spanish>
-            <Italian>Cadavere</Italian>
-            <Polish>Trup</Polish>
-            <Portuguese>Cadáver</Portuguese>
-            <Russian>Труп</Russian>
-            <German>Leiche</German>
-            <Korean>시체</Korean>
-            <Japanese>死体</Japanese>
-            <Chinese>屍體</Chinese>
-            <Chinesesimp>尸体</Chinesesimp>
-            <Turkish>Ceset</Turkish>
-        </Key>
         <Key ID="STR_MISERY_Currency_CurrentFunds">
             <English>Current funds</English>
             <Czech>Aktuální finance</Czech>

--- a/addons/currency/ui/moneyGiveMenu.hpp
+++ b/addons/currency/ui/moneyGiveMenu.hpp
@@ -1,6 +1,7 @@
 class CLASS(moneyGive_ui) {
     idd = 358493;
     onLoad = QUOTE([358493] call EFUNC(common,menuBlurEffect));
+    onUnload = QUOTE(call EFUNC(currency,exitGifting));
 
     class ControlsBackground {
         class CLASS(moneyGiveMenu_background): CLASS(RscText) {

--- a/addons/currency/ui/moneyTakeMenu.hpp
+++ b/addons/currency/ui/moneyTakeMenu.hpp
@@ -1,6 +1,7 @@
 class CLASS(moneyTake_ui) {
     idd = 358492;
     onLoad = QUOTE([358492] call EFUNC(common,menuBlurEffect));
+    onUnload = QUOTE(call EFUNC(currency,exitTaking));
 
     class ControlsBackground {
         class CLASS(moneyTakeMenu_background): CLASS(RscText) {

--- a/addons/poi/functions/fnc_generate.sqf
+++ b/addons/poi/functions/fnc_generate.sqf
@@ -226,6 +226,16 @@ if (_aiClass isNotEqualTo "") then {
             [_unit] call EFUNC(ambient_ai,addRecruitOption);
             [_unit] call EFUNC(ambient_ai,addGearOption);
         };
+
+        if (EGVAR(currency,corpseHasMoneyChance) > 0) then {
+            _unit setVariable [QEGVAR(currency,canSearch), true, true];
+            if ([EGVAR(currency,corpseHasMoneyChance)] call EFUNC(common,rollChance)) then {
+                private _cashFound = [EGVAR(currency,minAiMoney), EGVAR(currency,maxAiMoney)] call BIS_fnc_randomInt;
+                _unit setVariable [QEGVAR(currency,funds), _cashFound, true];
+            } else {
+                _unit setVariable [QEGVAR(currency,funds), 0, true];
+            };
+        };
     };
 
     if (count (_poi get "aiItemLoot") > 0) then {


### PR DESCRIPTION
**When merged this pull request will:**
- moved to UID for gifting recipient tracking rather than near checks

- added variable tracking for taking object no more near checks for money taking

- added funds setup on generated units for ambient_ai & poi's as well as WBK zc compat, funds are now placed on units as they are spawned and not handled through death EH's

- fixed poi ai not having money that can be taken

- improved searchable conditions to also include if a unit is unconscious or captive / surrendered (further ACE compat)

- made it so recruited unit's funds are changed once recruited handling so if they die the player can take their funds back

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
