### PR TITLE
Supply drop | Maintenance - Improve logic

### DIFF
--- a/addons/maintenance/XEH_PREP.hpp
+++ b/addons/maintenance/XEH_PREP.hpp
@@ -3,6 +3,7 @@ PREP(addCoolant);
 PREP(addOil);
 PREP(getBatteryCharge);
 PREP(initVehicles);
+PREP(ignore);
 PREP(listed);
 PREP(preparedVehicle);
 PREP(refuel);

--- a/addons/maintenance/XEH_postInit.sqf
+++ b/addons/maintenance/XEH_postInit.sqf
@@ -166,7 +166,11 @@ if (isServer) then {
                 [_target] call FUNC(updateIcon);
                 _player setVariable [QGVAR(currentVehicle), _target];
             },
-            {true}
+            {
+                params ["_target", "_player"];
+
+                !(_target getVariable [QGVAR(ignore), false]);
+            }
         ] call ACEFUNC(interact_menu,createAction);
 
         [_vehicle, 0, [QUOTE(ACE_MainActions)], _maintenanceAction] call ACEFUNC(interact_menu,addActionToObject);
@@ -176,6 +180,12 @@ if (isServer) then {
 
         _vehicle addEventHandler ["Engine", {
             params ["_vehicle", "_engineState"];
+
+            private _isIgnored = _vehicle getVariable [QGVAR(ignore), false];
+
+            if (_isIgnored) exitWith {
+                _vehicle removeEventHandler [_thisEvent, _thisEventHandler];
+            };
 
             private _requiredBatteries = _vehicle getVariable [QGVAR(batteryCount), 1];
             private _installedBatteries = _vehicle getVariable [QGVAR(installedBatteries), 0];

--- a/addons/maintenance/functions/fnc_ignore.sqf
+++ b/addons/maintenance/functions/fnc_ignore.sqf
@@ -1,0 +1,39 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Maintenance ignore
+ * Used for scripted vehicle events, for example Supply drops
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_maintenance_fnc_ignore;
+ *
+ * Public: No
+*/
+
+params ["_vehicle"];
+
+private _hitPoints = getAllHitPointsDamage _vehicle select 0;
+
+// Repair to 100%
+{
+    _vehicle setHitPointDamage [_x, 0];
+} forEach _hitPoints;
+
+// Set fuel to 100%
+_vehicle setFuel 1;
+
+// Strip maintenance variables
+_vehicle setVariable [QGVAR(batteryCount), nil, true];
+_vehicle setVariable [QGVAR(batteryType), nil, true];
+_vehicle setVariable [QGVAR(installedBatteries), nil, true];
+_vehicle setVariable [QGVAR(batteryLevel), nil, true];
+_vehicle setVariable [QGVAR(oilLevel), nil, true];
+_vehicle setVariable [QGVAR(coolantLevel), nil, true];
+
+_vehicle setVariable [QGVAR(ignore), true, true];

--- a/addons/maintenance/functions/fnc_vehicleStats.sqf
+++ b/addons/maintenance/functions/fnc_vehicleStats.sqf
@@ -21,6 +21,8 @@
 
     private _vehicle = objectParent ACE_player;
 
+    private _isIgnored = _vehicle getVariable [QGVAR(ignore), false];
+
     [_vehicle] call EFUNC(common,getObjectData) params ["_displayName"];
 
     // Make sure driver or pilot / co-pilot get display only
@@ -37,7 +39,7 @@
         };
     };
 
-    if (!alive ACE_player || isNull objectParent ACE_player) exitWith {
+    if (!alive ACE_player || isNull objectParent ACE_player || _isIgnored) exitWith {
         QGVAR(display) cutText ["", "PLAIN"];
         _handle call CBA_fnc_removePerFrameHandler;
     };

--- a/addons/supply_drop/functions/fnc_airSequence.sqf
+++ b/addons/supply_drop/functions/fnc_airSequence.sqf
@@ -22,6 +22,8 @@ if (_players isEqualTo []) exitWith {};
 private _dropZone = [getPosATL selectRandom _players, selectRandom GVAR(dropZones)] select (GVAR(dropZones) isNotEqualTo []);
 
 private _heli = createVehicle [selectRandom GVAR(heliTypes), [0, 0, 0], [], 0, "FLY"];
+[_heli] call EFUNC(maintenance,ignore);
+
 private _heliGroup = createVehicleCrew _heli;
 _heli setDir (_heli getDir _dropZone);
 

--- a/addons/supply_drop/functions/fnc_loop.sqf
+++ b/addons/supply_drop/functions/fnc_loop.sqf
@@ -14,6 +14,15 @@
  *
 */
 
+private _players = call EFUNC(common,listPlayers);
+
+// if no players in game, rerun loop after timedown
+if (_players isEqualTo []) exitWith {
+    [{
+        [] call FUNC(loop);
+    }, [], 10] call CBA_fnc_waitAndExecute;
+};
+
 if ([GVAR(spawnChance)] call EFUNC(common,rollChance)) then {
     [] call FUNC(airSequence);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- added player check in supply drop main loop, if no players in session, loop is rechecked every 10 seconds

- added ignore function to 'maintenance' component

- fixed supply drop heli's removed them from `maintenance` logic, keeping them from crashing on session start

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
