### PR TITLE
Common - Improve picture data retrieval

### DIFF
--- a/addons/common/functions/fnc_getObjectData.sqf
+++ b/addons/common/functions/fnc_getObjectData.sqf
@@ -22,7 +22,17 @@ if (isNil "_object") exitWith {};
 private _config = [_object] call CBA_fnc_getObjectConfig;
 
 private _displayName = getText (_config >> "displayName");
+
 private _picture = getText (_config >> "editorPreview");
 
-[_displayName, _picture]
+// If object is something like a backpack, grab it's regular picture
+if (_picture isEqualTo "") then {
+    _picture = getText (_config >> "picture");
+};
 
+// If no picture defined, just keep the return blank
+if (_picture in ["pictureStaticObject", "pictureThing"]) then {
+    _picture = "";
+};
+
+[_displayName, _picture]


### PR DESCRIPTION
**When merged this pull request will:**
- title, improved picture source retrieval to utilize "picture" & "editorPreview" data

- this is mainly for trader data since traders selling backpacks had no icon associated with the bags they were selling

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
