### PR TITLE
Medical | Survival - Improve player death events

### DIFF
--- a/addons/medical/functions/fnc_handleHeadTrauma.sqf
+++ b/addons/medical/functions/fnc_handleHeadTrauma.sqf
@@ -30,5 +30,5 @@ private _largeBruiseCount = 0;
 } forEach _headWounds;
 
 if (_largeBruiseCount >= 10) then {
-    [_unit] call ACEFUNC(medical_statemachine,enteredStateCardiacArrest);
+    [_unit] call ACEFUNC(medical_status,setDead);
 };

--- a/addons/medical/functions/fnc_handleRadiationExposure.sqf
+++ b/addons/medical/functions/fnc_handleRadiationExposure.sqf
@@ -35,5 +35,5 @@ private _largeBurnCount = 0;
 } forEach _bodyWounds;
 
 if (_largeBruiseCount >= 10 && _largeBurnCount >= 10) then {
-    [_unit] call ACEFUNC(medical_statemachine,enteredStateCardiacArrest);
+    [_unit] call ACEFUNC(medical_status,setDead);
 };

--- a/addons/survival/functions/fnc_visualizeDecay.sqf
+++ b/addons/survival/functions/fnc_visualizeDecay.sqf
@@ -37,6 +37,6 @@ if ([5] call EFUNC(common,rollChance)) then {
 
 if (_decay && _intensity >= 1) then {
     if ([5] call EFUNC(common,rollChance)) then {
-        [ACE_player] call ACEFUNC(medical_statemachine,enteredStateCardiacArrest);
+        [ACE_player] call ACEFUNC(medical_status,setDead);
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- title, removed cardiac arrest events, instead when players reach certain thresholds they will now immediately be killed, this fixes the seemingly endless unconscious time down till death

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
