### PR TITLE
Add - Gear Caches

### DIFF
--- a/addons/assets/CfgVehicles.hpp
+++ b/addons/assets/CfgVehicles.hpp
@@ -26,6 +26,10 @@ class CfgVehicles {
         scope = 1;
         ACEGVAR(minedetector,detectable) = 1;
     };
+    class CLASS(gearCache): Land_HelipadEmpty_F {
+        scope = 1;
+        ACEGVAR(minedetector,detectable) = 1;
+    };
 };
 
 

--- a/addons/gear_cache/$PBOPREFIX$
+++ b/addons/gear_cache/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\misery\addons\gear_cache

--- a/addons/gear_cache/CfgEventHandlers.hpp
+++ b/addons/gear_cache/CfgEventHandlers.hpp
@@ -1,0 +1,12 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+        clientInit = QUOTE(call COMPILE_SCRIPT(XEH_clientInit));
+    };
+};

--- a/addons/gear_cache/XEH_PREP.hpp
+++ b/addons/gear_cache/XEH_PREP.hpp
@@ -1,0 +1,5 @@
+PREP(condition);
+PREP(deserializeCache);
+PREP(initCrates);
+PREP(interaction);
+PREP(serializeCache);

--- a/addons/gear_cache/XEH_clientInit.sqf
+++ b/addons/gear_cache/XEH_clientInit.sqf
@@ -1,0 +1,27 @@
+#include "script_component.hpp"
+
+if (!hasInterface) exitWith {};
+
+GVAR(activeLogic) = objNull;
+
+["CBA_loadingScreenDone", {
+
+    [QCLASSACE(interactMenuOpened), {
+        params ["_type"];
+        if (_type isNotEqualTo 0) exitWith {};
+
+        [ACE_player] call FUNC(condition) params ["_found"];
+
+        if !(_found) exitWith {};
+
+        [] call FUNC(interaction);
+    }] call CBA_fnc_addEventHandler;
+
+    [QCLASSACE(interactMenuClosed), {
+        if (!isNull GVAR(activeLogic)) then {
+            [GVAR(activeLogic), 0, [QUOTE(ACE_MainActions), QGVAR(cache_menu)]] call ACEFUNC(interact_menu,removeActionFromObject);
+            deleteVehicle GVAR(activeLogic);
+            GVAR(activeLogic) = objNull;
+        };
+    }] call CBA_fnc_addEventHandler;
+}] call CBA_fnc_addEventHandler;

--- a/addons/gear_cache/XEH_postInit.sqf
+++ b/addons/gear_cache/XEH_postInit.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+if !(isServer) exitWith {};
+
+call FUNC(initCrates);

--- a/addons/gear_cache/XEH_preInit.sqf
+++ b/addons/gear_cache/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "XEH_PREP.hpp"
+
+ADDON = true;

--- a/addons/gear_cache/config.cpp
+++ b/addons/gear_cache/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {QCLASS(common)};
+        authors[] = {"TenuredCLOUD"};
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+
+

--- a/addons/gear_cache/functions/fnc_condition.sqf
+++ b/addons/gear_cache/functions/fnc_condition.sqf
@@ -1,0 +1,24 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Check for nearby gear caches
+ *
+ * Arguments:
+ * 0: Object <OBJECT>
+ *
+ * Return Value:
+ * 0: Cache found <BOOL>
+ * 1: Cache object <OBJECT>
+ *
+ * Example:
+ * [] call misery_gear_cache_fnc_condition;
+ *
+*/
+
+params ["_object"];
+
+private _nearObjects = nearestObjects [_object, [QCLASS(gearCache)], 1];
+
+if (_nearObjects isEqualTo []) exitWith {[false, objNull]};
+
+[true, _nearObjects select 0]

--- a/addons/gear_cache/functions/fnc_deserializeCache.sqf
+++ b/addons/gear_cache/functions/fnc_deserializeCache.sqf
@@ -1,0 +1,51 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Deserialize container cargo
+ *
+ * Arguments:
+ * 0: Container <OBJECT>
+ * 1: Container hash <HASHMAP>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_gear_cache_fnc_deserializeCache;
+ *
+*/
+
+params ["_container", "_cargoMap"];
+
+clearWeaponCargoGlobal _container;
+clearMagazineCargoGlobal _container;
+clearItemCargoGlobal _container;
+clearBackpackCargoGlobal _container;
+
+// Restore Weapons
+(_cargoMap getOrDefault ["weapons", [[], []]]) params ["_classes", "_counts"];
+
+{
+    _container addWeaponCargoGlobal [_x, _counts select _forEachIndex];
+} forEach _classes;
+
+// Restore Magazines
+(_cargoMap getOrDefault ["magazines", [[], []]]) params ["_classes", "_counts"];
+
+{
+    _container addMagazineCargoGlobal [_x, _counts select _forEachIndex];
+} forEach _classes;
+
+// Restore Items
+(_cargoMap getOrDefault ["items", [[], []]]) params ["_classes", "_counts"];
+
+{
+    _container addItemCargoGlobal [_x, _counts select _forEachIndex];
+} forEach _classes;
+
+// Restore Backpacks
+(_cargoMap getOrDefault ["backpacks", [[], []]]) params ["_classes", "_counts"];
+
+{
+    _container addBackpackCargoGlobal [_x, _counts select _forEachIndex];
+} forEach _classes;

--- a/addons/gear_cache/functions/fnc_initCrates.sqf
+++ b/addons/gear_cache/functions/fnc_initCrates.sqf
@@ -1,0 +1,83 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Adds bury action to crate objects
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_gear_cache_fnc_initCrates
+ *
+*/
+
+if !(isServer) exitWith {};
+
+["ReammoBox_F", "Init", {
+    params ["_crate"];
+
+    // If inheriting from "ReammoBox_F" but no carry capacity skip object
+    if (maxLoad _crate <= 0) exitWith {};
+
+    private _buryAction = [
+        QGVAR(crate_menu),
+        "Bury crate",
+        QPATHTOEF(icons,data\shovel_ca.paa),
+        {
+            params ["_target", "_player"];
+
+            // Dynamic digging duration based on crate load / size
+            private _digDuration = 10 + (maxLoad _target / 100);
+
+            [_player, "AinvPknlMstpSnonWnonDnon_medic4"] call ACEFUNC(common,doAnimation);
+
+            [
+                _digDuration,
+                [_target, _player],
+                {
+                    params ["_args"];
+                    _args params ["_target", "_player"];
+
+                    private _cargoMap = [_target] call FUNC(serializeCache);
+
+                    private _targetPos = getPosATL _target;
+
+                    private _cacheLogic = createVehicle [QCLASS(gearCache), _targetPos, [], 0, "CAN_COLLIDE"];
+
+                    _cacheLogic setVectorDirAndUp [_cargoMap get "containerVector" select 0, _cargoMap get "containerVector" select 1];
+
+                    _cacheLogic setVariable [QGVAR(data), _cargoMap, true];
+
+                    deleteVehicle _target;
+
+                    [_player, "", 1] call ACEFUNC(common,doAnimation);
+
+                    ["Stash buried...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+                },
+                {
+                    params ["_args"];
+                    _args params ["_target", "_player"];
+
+                    ["You stopped burying...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+                    [_player, "", 1] call ACEFUNC(common,doAnimation);
+                },
+                "Burying Cache..."
+            ] call ACEFUNC(common,progressBar);
+        },
+        {
+            params ["_target", "_player"];
+
+            insideBuilding _player isNotEqualTo 1 && [[MACRO_SHOVELS]] call EFUNC(common,hasItem);
+        },
+        {},
+        [],
+        [0, 0, 0],
+        3
+    ] call ACEFUNC(interact_menu,createAction);
+
+    [_crate, 0, [QUOTE(ACE_MainActions)], _buryAction] call ACEFUNC(interact_menu,addActionToObject);
+
+}, true, [], true] call CBA_fnc_addClassEventHandler;

--- a/addons/gear_cache/functions/fnc_initCrates.sqf
+++ b/addons/gear_cache/functions/fnc_initCrates.sqf
@@ -71,8 +71,9 @@ if !(isServer) exitWith {};
             params ["_target", "_player"];
 
             private _isCovered = [_target, 20] call EFUNC(common,hasOverheadCover);
+            private _isIgnored = _target getVariable [QGVAR(ignore), false];
 
-            !_isCovered && [[MACRO_SHOVELS]] call EFUNC(common,hasItem);
+            !_isCovered && !_isIgnored && [[MACRO_SHOVELS]] call EFUNC(common,hasItem);
         },
         {},
         [],

--- a/addons/gear_cache/functions/fnc_initCrates.sqf
+++ b/addons/gear_cache/functions/fnc_initCrates.sqf
@@ -24,7 +24,7 @@ if !(isServer) exitWith {};
 
     private _buryAction = [
         QGVAR(crate_menu),
-        "Bury crate",
+        localize LSTRING(BuryCrate),
         QPATHTOEF(icons,data\shovel_ca.paa),
         {
             params ["_target", "_player"];
@@ -55,22 +55,24 @@ if !(isServer) exitWith {};
 
                     [_player, "", 1] call ACEFUNC(common,doAnimation);
 
-                    ["Stash buried...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+                    [localize LSTRING(StashBuried), 1, [1, 1, 1, 1]] call CBA_fnc_notify;
                 },
                 {
                     params ["_args"];
                     _args params ["_target", "_player"];
 
-                    ["You stopped burying...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+                    [localize LSTRING(StopDigging), 1, [1, 1, 1, 1]] call CBA_fnc_notify;
                     [_player, "", 1] call ACEFUNC(common,doAnimation);
                 },
-                "Burying Cache..."
+                localize LSTRING(BuryingCache)
             ] call ACEFUNC(common,progressBar);
         },
         {
             params ["_target", "_player"];
 
-            insideBuilding _player isNotEqualTo 1 && [[MACRO_SHOVELS]] call EFUNC(common,hasItem);
+            private _isCovered = [_target, 20] call EFUNC(common,hasOverheadCover);
+
+            !_isCovered && [[MACRO_SHOVELS]] call EFUNC(common,hasItem);
         },
         {},
         [],

--- a/addons/gear_cache/functions/fnc_interaction.sqf
+++ b/addons/gear_cache/functions/fnc_interaction.sqf
@@ -26,7 +26,7 @@ if (_found) then {
 
     private _action = [
         QGVAR(cache_menu),
-        "Unbury cache",
+        localize LSTRING(DigUpCache),
         QPATHTOEF(icons,data\shovel_ca.paa),
         {
             params ["_target", "_player", "_params"];
@@ -63,16 +63,16 @@ if (_found) then {
 
                     [_player, "", 1] call ACEFUNC(common,doAnimation);
 
-                    ["Stash unburied...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+                    [localize LSTRING(StashDugUp), 1, [1, 1, 1, 1]] call CBA_fnc_notify;
                 },
                 {
                     params ["_args"];
                     _args params ["_target", "_player", "_cacheObject"];
 
-                    ["You stop digging...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+                    [localize LSTRING(StopDigging), 1, [1, 1, 1, 1]] call CBA_fnc_notify;
                     [_player, "", 1] call ACEFUNC(common,doAnimation);
                 },
-                "Digging up cache..."
+                localize LSTRING(DiggingUpCache)
             ] call ACEFUNC(common,progressBar);
         },
         {

--- a/addons/gear_cache/functions/fnc_interaction.sqf
+++ b/addons/gear_cache/functions/fnc_interaction.sqf
@@ -1,0 +1,88 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Add dynamic action to gear caches
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_gear_cache_fnc_interaction;
+ *
+*/
+
+[ACE_player] call FUNC(condition) params ["_found", "_cacheObject"];
+
+if (_found) then {
+
+    GVAR(activeLogic) = "ACE_LogicDummy" createVehicleLocal [0, 0, 0];
+
+    private _cachePos = getPosATL _cacheObject;
+
+    GVAR(activeLogic) setPosATL _cachePos;
+
+    private _action = [
+        QGVAR(cache_menu),
+        "Unbury cache",
+        QPATHTOEF(icons,data\shovel_ca.paa),
+        {
+            params ["_target", "_player", "_params"];
+            _params params ["_cacheObject"];
+
+            private _cacheData = _cacheObject getVariable [QGVAR(data), createHashMap];
+
+            private _digDuration = _cacheData get "digDuration";
+
+            [_player, "AinvPknlMstpSnonWnonDnon_medic4"] call ACEFUNC(common,doAnimation);
+
+            [
+                _digDuration,
+                [_target, _player, _cacheObject],
+                {
+                    params ["_args"];
+                    _args params ["_target", "_player", "_cacheObject"];
+
+                    private _cacheData = _cacheObject getVariable [QGVAR(data), createHashMap];
+
+                    private _class = _cacheData get "containerClass";
+
+                    private _pos = _cacheData get "containerPos";
+
+                    private _vector = _cacheData get "containerVector";
+
+                    private _newCrate = createVehicle [_class, _pos, [], 0, "CAN_COLLIDE"];
+
+                    _newCrate setVectorDirAndUp _vector;
+
+                    [_newCrate, _cacheData] call FUNC(deserializeCache);
+
+                    deleteVehicle _cacheObject;
+
+                    [_player, "", 1] call ACEFUNC(common,doAnimation);
+
+                    ["Stash unburied...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+                },
+                {
+                    params ["_args"];
+                    _args params ["_target", "_player", "_cacheObject"];
+
+                    ["You stop digging...", 1, [1, 1, 1, 1]] call CBA_fnc_notify;
+                    [_player, "", 1] call ACEFUNC(common,doAnimation);
+                },
+                "Digging up cache..."
+            ] call ACEFUNC(common,progressBar);
+        },
+        {
+            [[MACRO_SHOVELS]] call EFUNC(common,hasItem)
+        },
+        {},
+        [_cacheObject],
+        [0, 0, 0],
+        1
+    ] call ACEFUNC(interact_menu,createAction);
+
+    [GVAR(activeLogic), 0, [QUOTE(ACE_MainActions)], _action] call ACEFUNC(interact_menu,addActionToObject);
+};

--- a/addons/gear_cache/functions/fnc_serializeCache.sqf
+++ b/addons/gear_cache/functions/fnc_serializeCache.sqf
@@ -1,0 +1,34 @@
+#include "..\script_component.hpp"
+/*
+ * Author: TenuredCLOUD
+ * Serialize container cargo
+ *
+ * Arguments:
+ * 0: Container <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call misery_gear_cache_fnc_serializeCache;
+ *
+*/
+
+params ["_container"];
+
+private _cargoMap = createHashMap;
+
+_cargoMap set ["weapons", getWeaponCargo _container];
+_cargoMap set ["magazines", getMagazineCargo _container];
+_cargoMap set ["items", getItemCargo _container];
+_cargoMap set ["backpacks", getBackpackCargo _container];
+
+_cargoMap set ["containerClass", typeOf _container];
+
+_cargoMap set ["containerPos", getPosATL _container];
+
+_cargoMap set ["containerVector", [vectorDir _container, vectorUp _container]];
+
+_cargoMap set ["digDuration", 10 + (maxLoad _container / 100)];
+
+_cargoMap

--- a/addons/gear_cache/script_component.hpp
+++ b/addons/gear_cache/script_component.hpp
@@ -1,0 +1,16 @@
+#define COMPONENT gear_cache
+#define COMPONENT_BEAUTIFIED Gear Cache
+#include "\z\misery\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+
+#ifdef DEBUG_ENABLED_GEAR_CACHE
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_GEAR_CACHE
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_GEAR_CACHE
+#endif
+
+#include "\z\misery\addons\main\script_macros.hpp"

--- a/addons/gear_cache/stringtable.xml
+++ b/addons/gear_cache/stringtable.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="MISERY">
+    <Package name="Gear_cache">
+        <Key ID="STR_MISERY_Gear_cache_BuryCrate">
+            <English>Bury crate</English>
+            <Czech>Zakopat bednu</Czech>
+            <French>Enterrer la caisse</French>
+            <Spanish>Enterrar caja</Spanish>
+            <Italian>Seppellisci cassa</Italian>
+            <Polish>Zakop skrzynię</Polish>
+            <Portuguese>Enterrar caixa</Portuguese>
+            <Russian>Закопать ящик</Russian>
+            <German>Kiste eingraben</German>
+            <Korean>상자 묻기</Korean>
+            <Japanese>木箱を埋める</Japanese>
+            <Chinese>埋藏木箱</Chinese>
+            <Chinesesimp>埋藏木箱</Chinesesimp>
+            <Turkish>Sandığı göm</Turkish>
+        </Key>
+        <Key ID="STR_MISERY_Gear_cache_BuryingCache">
+            <English>Burying Cache...</English>
+            <Czech>Zakopávám skrýš...</Czech>
+            <French>Enterrement de la cache...</French>
+            <Spanish>Enterrando alijo...</Spanish>
+            <Italian>Seppellimento nascondiglio...</Italian>
+            <Polish>Zakopywanie schowka...</Polish>
+            <Portuguese>Enterrando esconderijo...</Portuguese>
+            <Russian>Закапывание тайника...</Russian>
+            <German>Versteck wird eingegraben...</German>
+            <Korean>은닉처 묻는 중...</Korean>
+            <Japanese>キャッシュを埋没中...</Japanese>
+            <Chinese>埋藏密藏中...</Chinese>
+            <Chinesesimp>埋藏密藏中...</Chinesesimp>
+            <Turkish>Zula gömülüyor...</Turkish>
+        </Key>
+        <Key ID="STR_MISERY_Gear_cache_DigUpCache">
+            <English>Dig up cache</English>
+            <Czech>Vykopat skrýš</Czech>
+            <French>Dérerterrer la cache</French>
+            <Spanish>Desenterrar alijo</Spanish>
+            <Italian>Disinterra nascondiglio</Italian>
+            <Polish>Wykop schowek</Polish>
+            <Portuguese>Desenterrar esconderijo</Portuguese>
+            <Russian>Откопать тайник</Russian>
+            <German>Versteck ausgraben</German>
+            <Korean>은닉처 파내기</Korean>
+            <Japanese>キャッシュを掘り起こす</Japanese>
+            <Chinese>挖掘密藏</Chinese>
+            <Chinesesimp>挖掘密藏</Chinesesimp>
+            <Turkish>Zulayı kazıp çıkar</Turkish>
+        </Key>
+        <Key ID="STR_MISERY_Gear_cache_DiggingUpCache">
+            <English>Digging up cache...</English>
+            <Czech>Vykopávám skrýš...</Czech>
+            <French>Déterrement de la cache...</French>
+            <Spanish>Desenterrando alijo...</Spanish>
+            <Italian>Disinterramento nascondiglio...</Italian>
+            <Polish>Wykopywanie schowka...</Polish>
+            <Portuguese>Desenterrando esconderijo...</Portuguese>
+            <Russian>Раскопавание тайника...</Russian>
+            <German>Versteck wird ausgegraben...</German>
+            <Korean>은닉처 파내는 중...</Korean>
+            <Japanese>キャッシュを掘り起こし中...</Japanese>
+            <Chinese>挖掘密藏中...</Chinese>
+            <Chinesesimp>挖掘密藏中...</Chinesesimp>
+            <Turkish>Zula kazılıyor...</Turkish>
+        </Key>
+        <Key ID="STR_MISERY_Gear_cache_StashBuried">
+            <English>Stash buried...</English>
+            <Czech>Skrýš zakopána...</Czech>
+            <French>Planque enterrée...</French>
+            <Spanish>Alijo enterrado...</Spanish>
+            <Italian>Nascondiglio sepolto...</Italian>
+            <Polish>Schowek zakopany...</Polish>
+            <Portuguese>Esconderijo enterrado...</Portuguese>
+            <Russian>Тайник закопан...</Russian>
+            <German>Versteck eingegraben...</German>
+            <Korean>은닉처를 묻었습니다...</Korean>
+            <Japanese>キャッシュを埋めました...</Japanese>
+            <Chinese>密藏已埋藏...</Chinese>
+            <Chinesesimp>密藏已埋藏...</Chinesesimp>
+            <Turkish>Zula gömüldü...</Turkish>
+        </Key>
+        <Key ID="STR_MISERY_Gear_cache_StashDugUp">
+            <English>Stash dug up...</English>
+            <Czech>Skrýš vykopána...</Czech>
+            <French>Planque déterrée...</French>
+            <Spanish>Alijo desenterrado...</Spanish>
+            <Italian>Nascondiglio disinterrato...</Italian>
+            <Polish>Schowek wykopany...</Polish>
+            <Portuguese>Esconderijo desenterrado...</Portuguese>
+            <Russian>Тайник откопан...</Russian>
+            <German>Versteck ausgegraben...</German>
+            <Korean>은닉처를 발굴했습니다...</Korean>
+            <Japanese>キャッシュを掘り起こしました...</Japanese>
+            <Chinese>密藏已挖掘...</Chinese>
+            <Chinesesimp>密藏已挖掘...</Chinesesimp>
+            <Turkish>Zula kazılıp çıkarıldı...</Turkish>
+        </Key>
+        <Key ID="STR_MISERY_Gear_cache_StopDigging">
+            <English>You stop digging...</English>
+            <Czech>Přestal jsi kopat...</Czech>
+            <French>Vous arrêtez de creuser...</French>
+            <Spanish>Dejas de excavar...</Spanish>
+            <Italian>Smetti di scavare...</Italian>
+            <Polish>Przestajesz kopać...</Polish>
+            <Portuguese>Você para de escavar...</Portuguese>
+            <Russian>Вы прекратили копать...</Russian>
+            <German>Du hörst auf zu graben...</German>
+            <Korean>굴착을 중단합니다...</Korean>
+            <Japanese>発掘作業を中止しました...</Japanese>
+            <Chinese>你停止了挖掘...</Chinese>
+            <Chinesesimp>你停止了挖掘...</Chinesesimp>
+            <Turkish>Kazmayı bıraktın...</Turkish>
+        </Key>
+    </Package>
+</Project>

--- a/addons/poi/functions/fnc_generate.sqf
+++ b/addons/poi/functions/fnc_generate.sqf
@@ -69,6 +69,9 @@ if (count _composition >= 3) then {
         };
 
         if (_class isKindOf "ReammoBox_F") then {
+
+            _obj setVariable [QEGVAR(gear_cache,ignore), true, true];
+
             clearMagazineCargoGlobal _obj;
             clearWeaponCargoGlobal _obj;
             clearItemCargoGlobal _obj;

--- a/addons/supply_drop/functions/fnc_airSequence.sqf
+++ b/addons/supply_drop/functions/fnc_airSequence.sqf
@@ -33,6 +33,8 @@ _heli flyInHeight 75;
 
 private _crate = createVehicle [selectRandom GVAR(crateTypes), position _heli vectorAdd [0, 0, -10], [], 0, "NONE"];
 
+_crate setVariable [QEGVAR(gear_cache,ignore), true, true];
+
 clearWeaponCargoGlobal _crate;
 clearMagazineCargoGlobal _crate;
 clearItemCargoGlobal _crate;


### PR DESCRIPTION
**When merged this pull request will:**
- title, added new  `gear_cache` component

- similar to money caches gear caches are for equipment stashing and are similarly detectable with the mine detector

- any crate can be buried and turned into a gear cache

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) from ACE are the expected standard.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
